### PR TITLE
unitaryfund/metriq-api#119: Faster submission detail view loading

### DIFF
--- a/src/views/Submission.js
+++ b/src/views/Submission.js
@@ -410,7 +410,7 @@ class Submission extends React.Component {
         const submission = subRes.data.data
 
         // Just get the view populated as quickly as possible, before we "trim."
-        this.setState({ item: submission })
+        this.setState({ isRequestFailed: false, requestFailedMessage: '', item: submission })
 
         const taskNamesRoute = config.api.getUriPrefix() + '/task/names'
         axios.get(taskNamesRoute)


### PR DESCRIPTION
See https://github.com/unitaryfund/metriq-api/issues/119.

We daisy-chain a few API calls in the submission detail view, in order to load the submission, but also task, method, and tag lists for editing. In this process, we trim already-associated task/method/tags from the "Add" function lists, by comparing to what's already associated with the submission details.

I originally thought we had to defer setting the submission details in view state, to wait for this trimming process. However, I have two new considerations:
1. This "trimming" process happens not to change the submission details, just the _other_ API call results for tasks/methods/tags.
2. Even if this process _did_ change the submission details, we could _still_ immediately set the submission details in view state and just update the state at the end of the process, with a delay of less than a second. (The view would probably render again, but they're be less time were it looked totally empty.)

So, here's a simple way to reduce loading time for the submission detail view.