### PR TITLE
Fixing text out of bounds.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -87,7 +87,7 @@ form > .row > label {
 }
 
 .submission-heading {
-  padding: 0 8px 8px 8px
+  padding-left: 80px;
 }
 
 .submission-image {
@@ -102,7 +102,7 @@ form > .row > label {
 
 .submission-description {
   text-align: left;
-  padding: 0 8px 8px 8px
+  padding-left: 80px;
 }
 
 .submission-button-block {


### PR DESCRIPTION
Not sure if this is the "proper" way to go about fixing the text out of bounds issue, but I tweaked the CSS for both the submission title and descriptions to add further padding on the left to prevent text from spilling over into the logo:

### Full resolution view:
<img width="1792" alt="Screen Shot 2021-10-19 at 9 37 12 AM" src="https://user-images.githubusercontent.com/1562214/137921159-18a91f45-073a-43de-b892-d3cdfdca6a7b.png">

### Condensed view:
<img width="907" alt="Screen Shot 2021-10-19 at 9 37 21 AM" src="https://user-images.githubusercontent.com/1562214/137921212-8ba522d2-985b-46a5-8d1c-22e4a8f6280f.png">

