### PR TITLE
187: Fixing about and faq formatting.

### DIFF
--- a/src/views/About.js
+++ b/src/views/About.js
@@ -1,25 +1,25 @@
 const About = () => {
   return (
     <div class='container content content-buffer '>
-      <div className='row'>
-        <div class='col-md-2' />
-        <div class='col-md-8'>
+      <div align='left' class='col-md-8'>
           <h1>Our Mission</h1>
           <p>
-            The mission of Metriq is to create a free and open resource for acting as the state-of-the-art in categorizing benchmarks for near-term quantum computers
+            The mission of metriq is to create a free and open resource for
+            acting as the state-of-the-art in categorizing benchmarks for
+            near-term quantum computers
           </p>
           <p>
             We believe this is best done together with the community.
           </p>
-
           <p>
-            All content on this website is openly licensed under CC-BY-SA (same as Wikipedia) and everyone can contribute - look for the "Edit" buttons!
+            All content on this website is openly licensed under CC-BY-SA (same
+            as Wikipedia) and everyone can contribute - look for the "Edit"
+            buttons!
           </p>
-
           <h2>Joining the community</h2>
-
-          <p>Join our community of contributors across academia and industry!</p>
-
+          <p>
+            Join our community of contributors across academia and industry!
+          </p>
           <p>
             We hang out on&nbsp;
             <a href='https://discord.gg/PZpWX3sh'>
@@ -32,7 +32,6 @@ const About = () => {
               Discord
             </a>, come join us!
           </p>
-
           <p>
             You can also follow us and get in touch on&nbsp;
             <a href='https://twitter.com/unitaryfund'>
@@ -51,59 +50,51 @@ const About = () => {
               </span> GitHub
             </a>.
           </p>
-
-          <h2 id='contributing'>Contributing</h2>
+          <h2>Contributing</h2>
           <p>
             Anyone can contribute - look for the "Edit" buttons!
           </p>
           <p>
-            Want to add an method, tag, or a task? You'll see edit buttons on the submission pages - just go ahead and edit! We found this a fun way to learn about new areas of quantum benchmarks and staying in tune with research.
+            Want to add an method, tag, or a task? You'll see edit buttons on
+            the submission pages - just go ahead and edit! We found this a fun
+            way to learn about new areas of quantum benchmarks and staying in
+            tune with research.
           </p>
-
           <p>
-            You can make use of the <a href='https://github.com/unitaryfund/metriq-client'>metriq-client</a> project to get and submit content to the Metriq platform.
+            You can make use of the <a
+            href='https://github.com/unitaryfund/metriq-client'>metriq-client</a>
+            project to get and submit content to the Metriq platform.
           </p>
-
           <p>
-            Please note that any contribution you make (i.e. linking code or submitting results) will be licensed under the free <a href='https://creativecommons.org/licenses/by-sa/4.0/'>CC BY-SA</a> licence.
+            Please note that any contribution you make (i.e. linking code or
+            submitting results) will be licensed under the free <a
+            href='https://creativecommons.org/licenses/by-sa/4.0/'>CC BY-SA</a>
+            licence.
           </p>
-
-          <h2 id='moderation'>Inclusion policy</h2>
-
+          <h2>Inclusion policy</h2>
           <p>
             To ensure high quality of data, all edits are monitored.
           </p>
-
-          <h2 id='date'>Downloading the data</h2>
+          <h2>Downloading the data</h2>
           <p>
-            All data is licensed under the <a href='https://creativecommons.org/licenses/by-sa/4.0/'>CC BY-SA</a> licence, same as Wikipedia.
+            All data is licensed under the <a
+            href='https://creativecommons.org/licenses/by-sa/4.0/'>CC BY-SA</a>
+            licence, same as Wikipedia.
           </p>
-          <p>
-            Download links:
-          </p>
-          <ul />
-
           <h2>Team</h2>
-
           <p>
-            The core Metriq team is based in the <a href='https://unitary.fund/'>Unitary Fund</a>.
+            The core metriq team is based in the <a
+            href='https://unitary.fund/'>Unitary Fund</a>.
           </p>
-
           <p>
-            Metriq is heavily influenced by the <a href='https://paperswithcode.com/'>Papers with Code</a> project created by Facebook AI Research.
+            The metriq project is heavily influenced by the <a
+            href='https://paperswithcode.com/'>Papers with Code</a> project
+            created by Facebook AI Research.
           </p>
-
           <p>
-            Metriq is a community project.
+            All contributions are welcome; metriq is a community project.
           </p>
-
-          <p>
-            All contributions are welcome!
-          </p>
-        </div>
-        <div class='col-md-2' />
       </div>
-
     </div>
   )
 }

--- a/src/views/FAQ.js
+++ b/src/views/FAQ.js
@@ -1,19 +1,18 @@
 const FAQ = () => {
   return (
     <div class='container content content-buffer '>
-      <div className='row'>
-        <div class='col-md-2' />
-        <div class='col-md-8'>
+      <div align='left' class='col-md-8'>
           <h1>F.A.Q.</h1>
           <h2>What is metriq?</h2>
           <p>
-            The purpose of the metriq platform is to allow users to answer the following question:
+            The purpose of the metriq platform is to allow users to answer the
+            following question:
             <blockquote>
-              How does quantum computing platform "X" running software stack
-              "Y" perform on workload "Z", and how has that changed over time?
+              How does quantum computing platform "X" running software stack "Y"
+              perform on workload "Z", and how has that changed over time?
             </blockquote>
-            Developers and companies can submit benchmarking results
-            easily, via web form or Python client.
+            Developers and companies can submit benchmarking results easily, via
+            web form or Python client.
           </p>
           <p>
             The goal of metriq is to become a focal point for present
@@ -24,8 +23,8 @@ const FAQ = () => {
             A metriq <b>"submission"</b> can be an arXiv preprint, GitHub
             repository, or links to peer reviewed and published articles. A
             submission can present or utilize one of more <b>"methods"</b> by
-            which they accomplish one or more <b>"tasks"</b>, which are workloads
-            of interest.
+            which they accomplish one or more <b>"tasks"</b>, which are
+            workloads of interest.
           </p>
           <p>
             <b>"Results"</b> are quantitative <b>metric</b> values at the
@@ -35,14 +34,11 @@ const FAQ = () => {
           <h2>How are submissions reviewed?</h2>
           <p>
             Submissions are received and reviewed by a panel to verify the
-            authenticity and claims of the benchmark. Once the submission
-            has been approved, it will appear under the main submission view
-            on metriq.
+            authenticity and claims of the benchmark. Once the submission has
+            been approved, it will appear under the main submission view on
+            metriq.
           </p>
-        </div>
-        <div class='col-md-2' />
       </div>
-
     </div>
   )
 }


### PR DESCRIPTION
Closes: #187 

Formatting on "About" and "F.A.Q." page is not left justified and formatted in a way that is more aligned with PWC:
<img width="1770" alt="Screen Shot 2021-10-19 at 11 20 02 AM" src="https://user-images.githubusercontent.com/1562214/137941168-1669bfda-b413-4f90-a59a-a2f0025b5545.png">

