### PR TITLE
Adding hover highlight to submission title.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -103,7 +103,17 @@ form > .row > label {
 }
 
 .submission-heading {
-  padding: 0 8px 8px 8px
+  font-size: 1em;
+  font-weight: bold;
+  cursor: pointer;
+}
+.submission-heading:hover {
+  color: #3cd2f9;
+  text-shadow: 0 0 10px #3cd2f9,
+               0 0 20px #3cd2f9,
+               0 0 40px #3cd2f9,
+               0 0 80px #3cd2f9,
+               0 0 120px #3cd2f9,
 }
 
 .submission-image {


### PR DESCRIPTION
Adding hover highlight to title text of submission title:

### Before highlight:
<img width="1097" alt="Screen Shot 2021-10-20 at 12 05 58 PM" src="https://user-images.githubusercontent.com/1562214/138130066-00ae89c6-cbdd-48cd-b6a5-a4209515ed72.png">


### After highlight:
<img width="1165" alt="Screen Shot 2021-10-20 at 12 06 10 PM" src="https://user-images.githubusercontent.com/1562214/138130087-624afc99-66b0-4fd8-bcc6-a8b14df2e9de.png">

Color code extracted from blue metriq logo with (#3cd2f9)