### PR TITLE
Truncating submission description to be first sentence only.

### DIFF
--- a/src/components/SubmissionBox.js
+++ b/src/components/SubmissionBox.js
@@ -74,7 +74,7 @@ class SubmissionBox extends React.Component {
             <div className='col-md-8 col h-100'>
               <div className='submission-heading'>{this.props.item.name} - Posted {this.props.item.createdAt ? new Date(this.props.item.createdAt).toLocaleDateString('en-US') : ''} {this.props.isEditView && ' - '} {this.props.isEditView && <b>{this.props.isUnderReview ? 'Under Review' : 'Approved'}</b>}</div>
               <div className='submission-description'>
-                {this.state.description ? this.state.description.split('.')[0] + '.' : <i>(No description provided.)</i>}
+                {this.state.description ? this.state.description.split('. ')[0] + '.' : <i>(No description provided.)</i>}
               </div>
             </div>
             <div className='col-md-2 col h-100'>


### PR DESCRIPTION
Closes: #184 

- Truncates the content in the description box to only be the first sentence.
<img width="1112" alt="Screen Shot 2021-10-20 at 1 35 45 PM" src="https://user-images.githubusercontent.com/1562214/138143109-6e712e1c-b757-4350-be4a-e847446f8802.png">
 
