### PR TITLE
210 Table stylistic improvements.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -185,7 +185,7 @@ form > .row > label {
 
 .detail-table td, #customers th {
   border: 1px solid #ddd;
-  padding: 8px;
+  padding: 12px;
 }
 
 .detail-table tr:nth-child(even){background-color: #f2f2f2;}
@@ -194,6 +194,7 @@ form > .row > label {
 
 .detail-table th {
   padding-top: 12px;
+  padding-left: 12px;
   padding-bottom: 12px;
   text-align: left;
   background-color: #34bce4;


### PR DESCRIPTION
Closes #210 

### Before:

<img width="1477" alt="Screen Shot 2021-10-23 at 9 58 37 AM" src="https://user-images.githubusercontent.com/1562214/138559573-327d390b-4f8a-4ff6-bd34-8d014b694fdc.png">

### After:

<img width="1532" alt="Screen Shot 2021-10-23 at 9 56 20 AM" src="https://user-images.githubusercontent.com/1562214/138559538-459d4d70-598d-46e4-bc3b-85d6e7de985c.png">


