### PR TITLE
218 Adding link of submission next to date.

### DIFF
--- a/src/components/SubmissionBox.js
+++ b/src/components/SubmissionBox.js
@@ -69,7 +69,7 @@ class SubmissionBox extends React.Component {
       return <span> <FontAwesomeIcon icon={faScroll} /> arXiv:{urlStr.split("/abs/")[1]} </span>
     }
     else if (urlStr.includes("github")) {
-      return <span> <FontAwesomeIcon icon={faCode} /> GitHub:{urlStr.split("/.com/")[1]} </span>
+      return <span> <FontAwesomeIcon icon={faCode} /> GitHub:{urlStr.split(".com/")[1]} </span>
     }
     else {
       return ""


### PR DESCRIPTION
Closes #218 

If link is GitHub or ArXiv, link is shown next to date of submission:

For instance:
<img width="1769" alt="Screen Shot 2021-10-27 at 12 56 47 PM" src="https://user-images.githubusercontent.com/1562214/139127913-b2171fba-9cd4-4b21-ad6b-5944ad49bf4d.png">


