### PR TITLE
160 Making modals wider.

### DIFF
--- a/src/views/Submission.js
+++ b/src/views/Submission.js
@@ -718,7 +718,12 @@ class Submission extends React.Component {
               </div>}
           </div>
         </div>
-        <Modal show={this.state.showAddModal} onHide={this.handleHideAddModal}>
+        <Modal 
+          show={this.state.showAddModal} onHide={this.handleHideAddModal}
+          size="lg"
+          aria-labelledby="contained-modal-title-vcenter"
+          centered
+        >
           {(this.state.modalMode === 'Login') &&
             <Modal.Header closeButton>
               <Modal.Title>Add</Modal.Title>


### PR DESCRIPTION
Closes #160 

Makes modals a bit wider that may prompt users to input more verbose text. For instance:

<img width="1792" alt="Screen Shot 2021-10-28 at 1 10 16 PM" src="https://user-images.githubusercontent.com/1562214/139303098-2d998784-72bf-4d24-bab3-a9df6099b388.png">

