### PR TITLE
223 Fixing unbolded logout.

### DIFF
--- a/src/components/AuthNav.js
+++ b/src/components/AuthNav.js
@@ -32,7 +32,7 @@ const AuthNav = (props) => {
         <NavDropdown.Item href='/Submissions'><p class='font-weight-bold'>My Submissions</p></NavDropdown.Item>
         <NavDropdown.Item href='/Token'><p class='font-weight-bold'>API Token</p></NavDropdown.Item>
         <NavDropdown.Divider />
-        <NavDropdown.Item onClick={handleOnClick}>Logout</NavDropdown.Item>
+        <NavDropdown.Item onClick={handleOnClick}><p class='font-weight-bold'>Logout</p></NavDropdown.Item>
       </NavDropdown>
     </Nav>
   )


### PR DESCRIPTION
Closes #223 

The "Logout" text in auth view is now properly bolded:
<img width="756" alt="Screen Shot 2021-10-28 at 1 18 20 PM" src="https://user-images.githubusercontent.com/1562214/139304103-b1d7882c-8bf0-4de7-82eb-53a8c1a546a2.png">


