### PR TITLE
232 Hovertext for buttons in submission box.

### DIFF
--- a/src/components/SubmissionBox.js
+++ b/src/components/SubmissionBox.js
@@ -96,7 +96,7 @@ class SubmissionBox extends React.Component {
                 <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Upvote submission</Tooltip>}>
                   <span><button className={'submission-button btn ' + (this.state.isUpvoted ? 'btn-primary' : 'btn-secondary')} onClick={this.handleUpVoteOnClick}><FontAwesomeIcon icon={faThumbsUp} /> {this.state.upvotes}</button><br /></span>
                 </OverlayTrigger>
-                <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Preprint</Tooltip>}>
+                <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Submission link</Tooltip>}>
                   <span><button className='submission-button btn btn-secondary' onClick={this.handleExternalLinkClick}><FontAwesomeIcon icon={faExternalLinkAlt} /></button></span>
                 </OverlayTrigger>
                 <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Delete submission</Tooltip>}>

--- a/src/views/Submission.js
+++ b/src/views/Submission.js
@@ -546,7 +546,7 @@ class Submission extends React.Component {
             <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Upvote submission</Tooltip>}>
               <button className={'submission-button btn ' + (this.state.item.isUpvoted ? 'btn-primary' : 'btn-secondary')} onClick={this.handleUpVoteOnClick}><FontAwesomeIcon icon='thumbs-up' /> {this.state.item.upvotesCount}</button>
             </OverlayTrigger>
-            <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Preprint</Tooltip>}>
+            <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Submission link</Tooltip>}>
               <button className='submission-button btn btn-secondary' onClick={() => { window.open(this.state.item.contentUrl, '_blank') }}><FontAwesomeIcon icon={faExternalLinkAlt} /></button>
             </OverlayTrigger>
             {this.state.isArxiv &&


### PR DESCRIPTION
Closes #232 

Helper text is now present for the upvote and preprint buttons on the main view in the submission box. 

### Upvote:
<img width="1143" alt="Screen Shot 2021-11-01 at 11 00 21 AM" src="https://user-images.githubusercontent.com/1562214/139692842-2f149f38-7979-4547-a540-a8151e70f23d.png">


### Preprint:
<img width="1138" alt="Screen Shot 2021-11-01 at 11 00 28 AM" src="https://user-images.githubusercontent.com/1562214/139692879-2303211e-9162-477e-9462-fc1a6085f310.png">
