### PR TITLE
#277: Fix metric names autocomplete population

### DIFF
--- a/src/views/Submission.js
+++ b/src/views/Submission.js
@@ -524,6 +524,17 @@ class Submission extends React.Component {
       .catch(err => {
         this.setState({ isRequestFailed: true, requestFailedMessage: ErrorHandler(err) })
       })
+
+    const metricNameRoute = config.api.getUriPrefix() + '/result/metricNames'
+    axios.get(metricNameRoute)
+      .then(subRes => {
+        const metricNames = subRes.data.data
+        console.log(metricNames)
+        this.setState({ metricNames: metricNames })
+      })
+      .catch(err => {
+        this.setState({ isRequestFailed: true, requestFailedMessage: ErrorHandler(err) })
+      })
   }
 
   render () {


### PR DESCRIPTION
Per #277, this fixes the metric name autocomplete text box, to give users a hint as to the metric name they should use. (There is a corresponding back end update, for this PR.)