### PR TITLE
#272: Make method description optional

### DIFF
--- a/src/views/Submission.js
+++ b/src/views/Submission.js
@@ -68,6 +68,7 @@ class Submission extends React.Component {
       method: {
         name: '',
         fullName: '',
+        description: '',
         submissions: this.props.match.params.id
       },
       taskId: '',


### PR DESCRIPTION
Per issue #272, this PR makes the method description an optional field.