### PR TITLE
#268: Make modal textarea form fields bigger

### DIFF
--- a/src/views/Method.js
+++ b/src/views/Method.js
@@ -143,7 +143,13 @@ class Method extends React.Component {
             </div>
           </div>
         </div>
-        <Modal show={this.state.showEditModal} onHide={this.handleHideEditModal}>
+        <Modal
+          show={this.state.showEditModal}
+          onHide={this.handleHideEditModal}
+          size='lg'
+          aria-labelledby='contained-modal-title-vcenter'
+          centered
+        >
           <Modal.Header closeButton>
             <Modal.Title>Edit Submission</Modal.Title>
           </Modal.Header>
@@ -155,7 +161,7 @@ class Method extends React.Component {
             {(this.state.modalMode !== 'Login') &&
               <span>
                 <FormFieldRow
-                  inputName='description' inputType='textarea' label='Description'
+                  inputName='description' inputType='textarea' label='Description' rows='12'
                   value={this.state.method.description}
                   onChange={(field, value) => this.handleOnChange('method', field, value)}
                 />

--- a/src/views/Submission.js
+++ b/src/views/Submission.js
@@ -996,7 +996,13 @@ class Submission extends React.Component {
             </Button>
           </Modal.Footer>
         </Modal>
-        <Modal show={this.state.showEditModal} onHide={this.handleHideEditModal}>
+        <Modal
+          show={this.state.showEditModal}
+          onHide={this.handleHideEditModal}
+          size='lg'
+          aria-labelledby='contained-modal-title-vcenter'
+          centered
+        >
           <Modal.Header closeButton>
             <Modal.Title>Edit Submission</Modal.Title>
           </Modal.Header>
@@ -1008,7 +1014,7 @@ class Submission extends React.Component {
             {(this.state.modalMode !== 'Login') &&
               <span>
                 <FormFieldRow
-                  inputName='description' inputType='textarea' label='Description'
+                  inputName='description' inputType='textarea' label='Description' rows='12'
                   value={this.state.submission.description}
                   onChange={(field, value) => this.handleOnChange('submission', field, value)}
                 />

--- a/src/views/Task.js
+++ b/src/views/Task.js
@@ -324,7 +324,13 @@ class Task extends React.Component {
             </div>}
           <div />
         </div>
-        <Modal show={this.state.showEditModal} onHide={this.handleHideEditModal}>
+        <Modal
+          show={this.state.showEditModal}
+          onHide={this.handleHideEditModal}
+          size='lg'
+          aria-labelledby='contained-modal-title-vcenter'
+          centered
+        >
           <Modal.Header closeButton>
             <Modal.Title>Edit Submission</Modal.Title>
           </Modal.Header>
@@ -336,7 +342,7 @@ class Task extends React.Component {
             {(this.state.modalMode !== 'Login') &&
               <span>
                 <FormFieldRow
-                  inputName='description' inputType='textarea' label='Description'
+                  inputName='description' inputType='textarea' label='Description' rows='12'
                   value={this.state.task.description}
                   onChange={(field, value) => this.handleOnChange('task', field, value)}
                 />


### PR DESCRIPTION
@vprusso, You had the right idea with the `react-bootstrap` modal styling properties, and thank you for finding those! Additionally, `textarea` inputs in all of these modals can default to 12 lines high, (even though the user can resize them vertically, as they wish).