### PR TITLE
Fix SOTA chart bounds

### DIFF
--- a/src/components/SotaChart.js
+++ b/src/components/SotaChart.js
@@ -30,7 +30,7 @@ function SotaChart (props) {
         .select('.tooltip')
         .remove()
 
-      const margin = { top: 20, right: 30, bottom: 60, left: 80 }
+      const margin = { top: 20, right: 160, bottom: 60, left: 80 }
       const lWidth = width - margin.left - margin.right
       const lHeight = height - margin.top - margin.bottom
       const yMinValue = d3.min(data, d => d.value)
@@ -130,7 +130,7 @@ function SotaChart (props) {
         .attr('transform', 'rotate(-90)')
         .text(yLabel)
 
-      const xLegendOffset = 150
+      const xLegendOffset = -5
       const yLegendOffset = 120
 
       const circleLegendKeys = ['Results']

--- a/src/views/Task.js
+++ b/src/views/Task.js
@@ -207,7 +207,7 @@ class Task extends React.Component {
                 tooltip='A metric performance measure of any "method" on this "task"'
               />
             </div>
-            <SotaChart data={this.state.chartData[this.state.chartKey]} width={900} height={400} xLabel='Date' xType='time' yLabel={this.state.chartKey} yType='number' isLowerBetter={this.state.isLowerBetterDict[this.state.chartKey]} />
+            <SotaChart data={this.state.chartData[this.state.chartKey]} width={1000} height={400} xLabel='Date' xType='time' yLabel={this.state.chartKey} yType='number' isLowerBetter={this.state.isLowerBetterDict[this.state.chartKey]} />
           </div>}
         <div className='container submission-detail-container'>
           <div className='row'>


### PR DESCRIPTION
This PR makes the SOTA chart canvas bounds look much better, without cut-off text.