### PR TITLE
Fix/generalize link styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -53,10 +53,6 @@
   padding-top: 20px;
 }
 
-.App-link {
-  color: #61dafb;
-}
-
 @keyframes App-logo-spin {
   from {
     transform: rotate(0deg);
@@ -177,11 +173,11 @@ form > .row > label {
   color: black;
 }
 
-.index-table-link {
+.link {
   color: #007bff;
 }
 
-.index-table-link:hover {
+.link:hover {
   color: #0000EE;
   text-decoration: underline;
 }

--- a/src/views/Method.js
+++ b/src/views/Method.js
@@ -138,7 +138,7 @@ class Method extends React.Component {
                   onClick () { window.location.href = '/Submission/' + record.key }
                 })}
                 tableLayout='auto'
-                rowClassName='index-table-link'
+                rowClassName='link'
               />
             </div>
           </div>

--- a/src/views/Submission.js
+++ b/src/views/Submission.js
@@ -632,7 +632,7 @@ class Submission extends React.Component {
                   onClick () { window.location.href = '/Task/' + record.key }
                 })}
                 tableLayout='auto'
-                rowClassName='index-table-link'
+                rowClassName='link'
                 showHeader={false}
               />}
             {(this.state.item.tasks.length === 0) &&
@@ -668,7 +668,7 @@ class Submission extends React.Component {
                   onClick () { window.location.href = '/Method/' + record.key }
                 })}
                 tableLayout='auto'
-                rowClassName='index-table-link'
+                rowClassName='link'
                 showHeader={false}
               />}
             {(this.state.item.methods.length === 0) &&
@@ -762,7 +762,7 @@ class Submission extends React.Component {
           <div className='col-md-12'>
             <hr />
             <div className='text-center'>
-              Notice something about this submission that needs moderation? <a href='#' onClick={this.handleModerationReport}>Let us know.</a>
+              Notice something about this submission that needs moderation? <span className='link' onClick={this.handleModerationReport}>Let us know.</span>
             </div>
           </div>
         </div>

--- a/src/views/Task.js
+++ b/src/views/Task.js
@@ -275,7 +275,7 @@ class Task extends React.Component {
                       onClick () { window.location.href = '/Submission/' + record.key }
                     })}
                     tableLayout='auto'
-                    rowClassName='index-table-link'
+                    rowClassName='link'
                   />
                 </div>
               </div>
@@ -323,7 +323,7 @@ class Task extends React.Component {
                         onClick () { window.location.href = '/Submission/' + record.key }
                       })}
                       tableLayout='auto'
-                      rowClassName='index-table-link'
+                      rowClassName='link'
                     />
                   </div>
                 </div>}


### PR DESCRIPTION
We had a warning for an anchor tag pointing to `#`. Anticipating that this case will arise repeatedly, this generalizes a solution, for `onClick` handlers that need to look like links.