### PR TITLE
#361: Let members edit results

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -24,6 +24,10 @@
   font-size: calc(10px + 2vmin);
 }
 
+.text-center {
+  text-align: center;
+}
+
 .display-linebreak {
   white-space: pre-line;
 }

--- a/src/components/FormFieldRow.js
+++ b/src/components/FormFieldRow.js
@@ -77,6 +77,7 @@ class FormFieldRow extends React.Component {
                   type={this.props.inputType}
                   selected={this.props.defaultValue}
                   value={this.props.value}
+                  checked={this.props.checked}
                   onChange={this.handleOnFieldChange}
                   onBlur={this.handleOnFieldBlur}
                 />}


### PR DESCRIPTION
Per #361, these are the front end changes to let users edit results, without deleting them and adding them a second time.