### PR TITLE
#368: Show submitting username in SubmissionBox

### DIFF
--- a/src/components/SubmissionBox.js
+++ b/src/components/SubmissionBox.js
@@ -98,7 +98,7 @@ class SubmissionBox extends React.Component {
               <div className='submission-subheading'>
                 <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Submission link</Tooltip>}>
                   <span onClick={this.handleExternalLinkClick}>
-                    {this.parseContentUrl()} • {this.props.item.createdAt ? new Date(this.props.item.createdAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }) : ''} •
+                    Submitted by {this.props.item.username} • {this.parseContentUrl()} • {this.props.item.createdAt ? new Date(this.props.item.createdAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }) : ''} •
                   </span>
                 </OverlayTrigger>
               </div>


### PR DESCRIPTION
As a first step in development, for expanded "social credit" and social media functionality, we show the submitting username for each `SubmissionBox`.