### PR TITLE
#354: Replace social link to metriq-api repo with metriq-app repo

### DIFF
--- a/src/components/AnonNavRight.js
+++ b/src/components/AnonNavRight.js
@@ -7,7 +7,7 @@ const AnonNavRight = () => {
   return (
     <Nav className='ml-auto metriq-navbar'>
       <Nav.Link href='http://discord.unitary.fund'> <FaDiscord color={`${'black'}`} size={25} /> </Nav.Link>
-      <Nav.Link href='https://github.com/unitaryfund/metriq-api'> <FaGithub color={`${'black'}`} size={25} /> </Nav.Link>
+      <Nav.Link href='https://github.com/unitaryfund/metriq-app'> <FaGithub color={`${'black'}`} size={25} /> </Nav.Link>
       <Nav.Link href='/Login' className='metriq-navbar-text'>Log In</Nav.Link>
       <Nav.Link href='/Login/AddSubmission'><Button variant='primary' className='metriq-navbar-button'>Submit</Button></Nav.Link>
     </Nav>

--- a/src/components/AuthNavRight.js
+++ b/src/components/AuthNavRight.js
@@ -19,7 +19,7 @@ const AuthNavRight = () => {
   return (
     <Nav className='ml-auto metriq-navbar'>
       <Nav.Link href='http://discord.unitary.fund'> <FaDiscord color={`${'black'}`} size={25} /> </Nav.Link>
-      <Nav.Link href='https://github.com/unitaryfund/metriq-api'> <FaGithub color={`${'black'}`} size={25} /> </Nav.Link>
+      <Nav.Link href='https://github.com/unitaryfund/metriq-app'> <FaGithub color={`${'black'}`} size={25} /> </Nav.Link>
       <NavDropdown title='Account' active='true' className='metriq-navbar-text' alignRight>
         <NavDropdown.Item href='/Profile'><p class='font-weight-bold'>Settings</p></NavDropdown.Item>
         <NavDropdown.Item href='/AddSubmission'><p class='font-weight-bold'>Add Submission</p></NavDropdown.Item>


### PR DESCRIPTION
(Per #354...) It's unfortunate that our primary issue board is not in the same repo as our parent project, but I think I agree with Nathan that it makes more sense to direct social links to the primary issues board. We're somewhat stuck with this being "backwards" like this, but users are probably more frequently going to be interested in opening issue tickets than in cloning the 3 repos.