### PR TITLE
#376: Redirect AddSubmission to login if anonymous

### DIFF
--- a/src/MainRouter.js
+++ b/src/MainRouter.js
@@ -111,7 +111,7 @@ const MainRouter = (props) => {
       <Route
         exact
         path='/AddSubmission'
-        component={AddSubmission}
+        render={(p) => <AddSubmission {...p} isLoggedIn={props.isLoggedIn} />}
       />
       <Route
         exact

--- a/src/views/AddSubmission.js
+++ b/src/views/AddSubmission.js
@@ -25,6 +25,10 @@ class AddSubmission extends React.Component {
       isValidated: false
     }
 
+    if (!this.props.isLoggedIn) {
+      window.location.href = '/LogIn/AddSubmission'
+    }
+
     this.handleOnChange = this.handleOnChange.bind(this)
     this.isAllValid = this.isAllValid.bind(this)
     this.handleOnSubmit = this.handleOnSubmit.bind(this)


### PR DESCRIPTION
This closes #376. If an anonymous user directly navigates to the URL to add a new submission, they are redirected to the login view instead, (which will next redirect them back to the new submission view after they log in).