### PR TITLE
Adding share buttons to method, submission, and task.

### DIFF
--- a/src/views/Method.js
+++ b/src/views/Method.js
@@ -4,11 +4,14 @@ import config from './../config'
 import Table from 'rc-table'
 import ErrorHandler from './../components/ErrorHandler'
 import FormFieldRow from '../components/FormFieldRow'
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
+import Tooltip from 'react-bootstrap/Tooltip'
 import { Button, Modal } from 'react-bootstrap'
 import { Link } from 'react-router-dom'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { faEdit } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { FacebookShareButton, TwitterShareButton, FacebookIcon, TwitterIcon } from 'react-share'
 
 library.add(faEdit)
 
@@ -99,7 +102,23 @@ class Method extends React.Component {
           </div>
           <div className='row'>
             <div className='col-md-12'>
-              <button className='submission-button btn btn-secondary' onClick={this.handleShowEditModal}><FontAwesomeIcon icon='edit' /></button>
+              <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Edit method</Tooltip>}>
+                <button className='submission-button btn btn-secondary' onClick={this.handleShowEditModal}><FontAwesomeIcon icon='edit' /></button>
+              </OverlayTrigger>
+              <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Share via Facebook</Tooltip>}>
+                <button className='submission-button btn-secondary'>
+                  <FacebookShareButton url={config.api.getUriPrefix() + '/method/' + this.props.match.params.id}>
+                    <FacebookIcon size={32} />
+                  </FacebookShareButton>
+                </button>
+              </OverlayTrigger>
+              <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Share via Twitter</Tooltip>}>
+                <button className='submission-button btn-secondary'>
+                  <TwitterShareButton url={config.api.getUriPrefix() + '/method/' + this.props.match.params.id}>
+                    <TwitterIcon size={32} />
+                  </TwitterShareButton>
+                </button>
+              </OverlayTrigger>
             </div>
           </div>
           <br />

--- a/src/views/Submission.js
+++ b/src/views/Submission.js
@@ -14,6 +14,7 @@ import { Link } from 'react-router-dom'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEdit, faExternalLinkAlt, faHeart, faPlus, faTrash, faMobileAlt, faStickyNote, faSuperscript } from '@fortawesome/free-solid-svg-icons'
+import { FacebookShareButton, TwitterShareButton, FacebookIcon, TwitterIcon } from 'react-share'
 
 library.add(faEdit, faExternalLinkAlt, faHeart, faPlus, faTrash, faMobileAlt, faStickyNote, faSuperscript)
 
@@ -647,6 +648,20 @@ class Submission extends React.Component {
               </span>}
             <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Edit submission</Tooltip>}>
               <button className='submission-button btn btn-secondary' onClick={this.handleAddDescription}><FontAwesomeIcon icon='edit' /></button>
+            </OverlayTrigger>
+            <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Share via Facebook</Tooltip>}>
+              <button className='submission-button btn-secondary'>
+                <FacebookShareButton url={config.api.getUriPrefix() + '/submission/' + this.props.match.params.id}>
+                  <FacebookIcon size={32} />
+                </FacebookShareButton>
+              </button>
+            </OverlayTrigger>
+            <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Share via Twitter</Tooltip>}>
+              <button className='submission-button btn-secondary'>
+                <TwitterShareButton url={config.api.getUriPrefix() + '/submission/' + this.props.match.params.id}>
+                  <TwitterIcon size={32} />
+                </TwitterShareButton>
+              </button>
             </OverlayTrigger>
           </div>
         </div>

--- a/src/views/Task.js
+++ b/src/views/Task.js
@@ -5,6 +5,8 @@ import Table from 'rc-table'
 import ErrorHandler from './../components/ErrorHandler'
 import FormFieldRow from '../components/FormFieldRow'
 import FormFieldSelectRow from '../components/FormFieldSelectRow'
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
+import Tooltip from 'react-bootstrap/Tooltip'
 import { Button, Modal } from 'react-bootstrap'
 import { Link } from 'react-router-dom'
 import { library } from '@fortawesome/fontawesome-svg-core'
@@ -227,17 +229,23 @@ class Task extends React.Component {
           </div>
           <div className='row'>
             <div className='col-md-12'>
+              <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Edit task</Tooltip>}>
               <button className='submission-button btn btn-secondary' onClick={this.handleShowEditModal}><FontAwesomeIcon icon='edit' /></button>
-              <FacebookShareButton
-                url={config.api.getUriPrefix() + '/task/' + this.props.match.params.id}
-              >
-                <FacebookIcon size={32} />
-              </FacebookShareButton>
-              <TwitterShareButton
-                url={config.api.getUriPrefix() + '/task/' + this.props.match.params.id}
-              >
-                <TwitterIcon size={32} />
-              </TwitterShareButton>
+              </OverlayTrigger>
+              <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Share via Facebook</Tooltip>}>
+                <button className='submission-button btn-secondary'>
+                  <FacebookShareButton url={config.api.getUriPrefix() + '/task/' + this.props.match.params.id}>
+                    <FacebookIcon size={32} />
+                  </FacebookShareButton>
+                </button>
+              </OverlayTrigger>
+              <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Share via Twitter</Tooltip>}>
+                <button className='submission-button btn-secondary'>
+                  <TwitterShareButton url={config.api.getUriPrefix() + '/task/' + this.props.match.params.id}>
+                    <TwitterIcon size={32} />
+                  </TwitterShareButton>
+                </button>
+              </OverlayTrigger>
             </div>
           </div>
           <br />


### PR DESCRIPTION
Closes #425 

- Adding FB/Twitter share buttons to "method" and "submission" pages
- Improving the "look" of the social share buttons.