### PR TITLE
#411: Top level topics

### DIFF
--- a/src/views/Method.js
+++ b/src/views/Method.js
@@ -103,6 +103,45 @@ class Method extends React.Component {
             </div>
           </div>
           <br />
+          {this.state.item.parentMethod &&
+            <div className='row'>
+              <div className='col-md-12'>
+                <div className='submission-description'>
+                  <b>Parent method:</b> <a href={'/Method/' + this.state.item.parentMethod.id}>{this.state.item.parentMethod.name}</a>
+                </div>
+              </div>
+              <br />
+            </div>}
+          {(this.state.item.childMethods && (this.state.item.childMethods.length > 0)) &&
+            <div>
+              <h2>Child Methods</h2>
+              <div className='row'>
+                <div className='col-md-12'>
+                  <Table
+                    className='detail-table'
+                    columns={[{
+                      title: 'Name',
+                      dataIndex: 'name',
+                      key: 'name',
+                      width: 700
+                    }]}
+                    data={this.state.item.childMethods
+                      ? this.state.item.childMethods.map(row => ({
+                          key: row.id,
+                          name: row.name
+                        }))
+                      : []}
+                    onRow={(record) => ({
+                      onClick () { window.location.href = '/Method/' + record.key }
+                    })}
+                    tableLayout='auto'
+                    rowClassName='link'
+                  />
+                </div>
+              </div>
+              <br />
+            </div>}
+          <br/>
           <h2>Submissions</h2>
           <div className='row'>
             <div className='col-md-12'>

--- a/src/views/Submission.js
+++ b/src/views/Submission.js
@@ -884,6 +884,14 @@ class Submission extends React.Component {
                           validRegex={methodNameRegex}
                           tooltip='Long name of new method'
                         /><br />
+                        <FormFieldSelectRow
+                          inputName='parentMethod'
+                          label='Parent method<br/>(if any)'
+                          isNullDefault
+                          options={this.state.allMethodNames}
+                          onChange={(field, value) => this.handleOnChange('method', field, value)}
+                          tooltip='Optionally, the new method is a sub-method of a "parent" method.'
+                        /><br />
                         <FormFieldRow
                           inputName='description'
                           inputType='textarea'

--- a/src/views/Task.js
+++ b/src/views/Task.js
@@ -198,7 +198,7 @@ class Task extends React.Component {
   render () {
     return (
       <div id='metriq-main-content'>
-        {(this.state.metricNames.length > 0) &&
+        {!this.state.item.isHideChart && (this.state.metricNames.length > 0) &&
           <div>
             <div className='container'>
               <FormFieldSelectRow


### PR DESCRIPTION
This makes methods into a hierarchy equivalent to tasks, restricts method and task index views to top level, and gives administrators the option to hide SOTA comparison charts for tasks. These changes let administrators use top level tasks and methods in the database as very general categories, (without displaying confusing or poorly motivated top level task category SOTA comparisons).