### PR TITLE
Fix React.js warnings

### DIFF
--- a/src/components/FormFieldSelectRow.js
+++ b/src/components/FormFieldSelectRow.js
@@ -54,11 +54,12 @@ class FormFieldSelectRow extends React.Component {
             onChange={this.handleOnFieldChange}
             onBlur={this.handleOnFieldBlur}
             disabled={this.props.disabled}
+            value={this.props.value}
           >
             {this.props.isNullDefault &&
               <option value=''>(None)</option>}
             {this.props.options.map(option =>
-              <option key={option.id} value={option.id} selected={option.id === this.props.value}>{option.name}</option>
+              <option key={option.id} value={option.id}>{option.name}</option>
             )}
           </select>
         </div>

--- a/src/views/Method.js
+++ b/src/views/Method.js
@@ -141,18 +141,14 @@ class Method extends React.Component {
                 <button className='submission-button btn btn-secondary' onClick={this.handleShowEditModal}><FontAwesomeIcon icon='edit' /></button>
               </OverlayTrigger>
               <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Share via Facebook</Tooltip>}>
-                <button className='submission-button btn-secondary'>
-                  <FacebookShareButton url={config.api.getUriPrefix() + '/method/' + this.props.match.params.id}>
-                    <FacebookIcon size={32} />
-                  </FacebookShareButton>
-                </button>
+                <FacebookShareButton url={config.api.getUriPrefix() + '/method/' + this.props.match.params.id}>
+                  <FacebookIcon size={32} />
+                </FacebookShareButton>
               </OverlayTrigger>
               <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Share via Twitter</Tooltip>}>
-                <button className='submission-button btn-secondary'>
-                  <TwitterShareButton url={config.api.getUriPrefix() + '/method/' + this.props.match.params.id}>
-                    <TwitterIcon size={32} />
-                  </TwitterShareButton>
-                </button>
+                <TwitterShareButton url={config.api.getUriPrefix() + '/method/' + this.props.match.params.id}>
+                  <TwitterIcon size={32} />
+                </TwitterShareButton>
               </OverlayTrigger>
             </div>
           </div>

--- a/src/views/Submission.js
+++ b/src/views/Submission.js
@@ -661,18 +661,14 @@ class Submission extends React.Component {
               <button className='submission-button btn btn-secondary' onClick={this.handleAddDescription}><FontAwesomeIcon icon='edit' /></button>
             </OverlayTrigger>
             <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Share via Facebook</Tooltip>}>
-              <button className='submission-button btn-secondary'>
-                <FacebookShareButton url={config.api.getUriPrefix() + '/submission/' + this.props.match.params.id}>
-                  <FacebookIcon size={32} />
-                </FacebookShareButton>
-              </button>
+              <FacebookShareButton url={config.api.getUriPrefix() + '/submission/' + this.props.match.params.id}>
+                <FacebookIcon size={32} />
+              </FacebookShareButton>
             </OverlayTrigger>
             <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Share via Twitter</Tooltip>}>
-              <button className='submission-button btn-secondary'>
-                <TwitterShareButton url={config.api.getUriPrefix() + '/submission/' + this.props.match.params.id}>
-                  <TwitterIcon size={32} />
-                </TwitterShareButton>
-              </button>
+              <TwitterShareButton url={config.api.getUriPrefix() + '/submission/' + this.props.match.params.id}>
+                <TwitterIcon size={32} />
+              </TwitterShareButton>
             </OverlayTrigger>
           </div>
         </div>

--- a/src/views/Task.js
+++ b/src/views/Task.js
@@ -260,18 +260,14 @@ class Task extends React.Component {
                 <button className='submission-button btn btn-secondary' onClick={this.handleShowEditModal}><FontAwesomeIcon icon='edit' /></button>
               </OverlayTrigger>
               <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Share via Facebook</Tooltip>}>
-                <button className='submission-button btn-secondary'>
-                  <FacebookShareButton url={config.api.getUriPrefix() + '/task/' + this.props.match.params.id}>
-                    <FacebookIcon size={32} />
-                  </FacebookShareButton>
-                </button>
+                <FacebookShareButton url={config.api.getUriPrefix() + '/task/' + this.props.match.params.id}>
+                  <FacebookIcon size={32} />
+                </FacebookShareButton>
               </OverlayTrigger>
               <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Share via Twitter</Tooltip>}>
-                <button className='submission-button btn-secondary'>
-                  <TwitterShareButton url={config.api.getUriPrefix() + '/task/' + this.props.match.params.id}>
-                    <TwitterIcon size={32} />
-                  </TwitterShareButton>
-                </button>
+                <TwitterShareButton url={config.api.getUriPrefix() + '/task/' + this.props.match.params.id}>
+                  <TwitterIcon size={32} />
+                </TwitterShareButton>
               </OverlayTrigger>
             </div>
           </div>


### PR DESCRIPTION
If one checks the browser console, this fixes two warnings/error in the app: buttons cannot be nested within buttons, and `value` property on `<select>` should be used instead of `selected` property on nested `<option>` tags.