### PR TITLE
#451: Center CategoryItemBox text when description is blank

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -148,6 +148,10 @@ form > .row > label {
   padding: 0 8px 8px 8px
 }
 
+.submission-heading-only {
+  font-weight: bold;
+}
+
 .submission-subheading {
   font-size: 80%;
   padding: 0 8px 8px 8px

--- a/src/components/CategoryItemBox.js
+++ b/src/components/CategoryItemBox.js
@@ -16,8 +16,13 @@ class CategoryItemBox extends React.Component {
           <div className='row submission'>
             <div className='col-md-8'>
               <Link to={(this.props.type === 'tag') ? ('/Tag/' + this.props.item.name) : (((this.props.type === 'task') ? '/Task/' : '/Method/') + this.props.item.id)}>
-                <div className='submission-heading'>{this.props.item.name}</div>
-                <div className='submission-description'>{this.props.item.description}</div>
+                {this.props.item.description &&
+                  <div>
+                    <div className='submission-heading'>{this.props.item.name}</div>
+                    <div className='submission-description'>{this.props.item.description}</div>
+                  </div>}
+                {!this.props.item.description &&
+                  <div className='submission-heading-only'>{this.props.item.name}</div>}
               </Link>
             </div>
             <div className='col-md-2'>


### PR DESCRIPTION
This addresses #451, by using React.js to dynamically reformat the `CategoryItemBox` DOM when the "description" field is empty.