### PR TITLE
#271: Submission description placeholder

### DIFF
--- a/src/components/FormFieldRow.js
+++ b/src/components/FormFieldRow.js
@@ -66,6 +66,7 @@ class FormFieldRow extends React.Component {
                   onBlur={this.handleOnFieldBlur}
                   rows={this.props.rows}
                   cols={this.props.cols}
+                  placeholder={this.props.placeholder}
                 >
                   {this.props.value}
                 </textarea>}

--- a/src/views/AddSubmission.js
+++ b/src/views/AddSubmission.js
@@ -137,6 +137,7 @@ class AddSubmission extends React.Component {
           </div>
           <FormFieldRow
             inputName='description' inputType='textarea' label='Description'
+            placeholder='Explain the content of the submission URL at a high level, as one would with a peer-reviewed research article abstract...'
             onChange={this.handleOnChange}
           />
           <div className='row'>


### PR DESCRIPTION
This adds a submission description placeholder hint, per #271.

@crazy4pi314 Looking at the particular text of the placeholder that I give here, is there anything you think we should add? I think an appropriate description could follow any style guide for a research article abstract, personally.