### PR TITLE
#505: Explain usage of standard error to members

### DIFF
--- a/src/views/Submission.js
+++ b/src/views/Submission.js
@@ -1051,7 +1051,7 @@ class Submission extends React.Component {
                   value={this.state.result.standardError}
                   validRegex={standardErrorRegex}
                   onChange={(field, value) => this.handleOnChange('result', field, value)}
-                  tooltip='Confidence intervals will be calculated as ± standard error times z-score, if you report a standard error. This is self-consistent if your statistics are Gaussian or Poisson, for example, over a linear scale of the metric. (If Gaussian or Poisson statistics emerge over a different, non-linear scale of the metric, consider reporting your metric value with rescaled units.)'
+                  tooltip='Confidence intervals will be calculated as (mean) result metric value ± standard error times z-score, if you report a standard error. This is self-consistent if your statistics are Gaussian or Poisson, for example, over a linear scale of the metric. (If Gaussian or Poisson statistics emerge over a different, non-linear scale of the metric, consider reporting your metric value with rescaled units.)'
                 /><br />
                 <FormFieldRow
                   inputName='sampleSize' inputType='number' label='Sample size (optional)'

--- a/src/views/Submission.js
+++ b/src/views/Submission.js
@@ -1051,14 +1051,14 @@ class Submission extends React.Component {
                   value={this.state.result.standardError}
                   validRegex={standardErrorRegex}
                   onChange={(field, value) => this.handleOnChange('result', field, value)}
-                  tooltip='Report the Gaussian standard error of the (mean) metric value. (The combination of standard error and sample size will be used to calculate other statistics, like confidence intervals.)'
+                  tooltip='Confidence intervals will be calculated as ± standard error times z-score, if you report a standard error. This is self-consistent if your statistics are Gaussian or Poisson, for example, over a linear scale of the metric. (If Gaussian or Poisson statistics emerge over a different, non-linear scale of the metric, consider reporting your metric value with rescaled units.)'
                 /><br />
                 <FormFieldRow
                   inputName='sampleSize' inputType='number' label='Sample size (optional)'
                   value={this.state.result.sampleSize}
                   validRegex={sampleSizeRegex}
                   onChange={(field, value) => this.handleOnChange('result', field, value)}
-                  tooltip='Report the sample size used to calculate the metric value. (The combination of standard error and sample size will be used to calculate other statistics, like confidence intervals.)'
+                  tooltip='Report the sample size used to calculate the metric value.'
                 /><br />
                 <FormFieldRow
                   inputName='notes' inputType='textarea' label='Notes'


### PR DESCRIPTION
Per #505, the notes on "standard error" have been updated to make its usage and theoretical usage transparent.

@crazy4pi314, If you look at the exact text of the tool-tips, I feel confident saying exactly this:

> Confidence intervals will be calculated as ± standard error times z-score, if you report a standard error. This is self-consistent if your statistics are Gaussian or Poisson, for example, over a linear scale of the metric. (If Gaussian or Poisson statistics emerge over a different, non-linear scale of the metric, consider reporting your metric value with rescaled units.)

To the best of my knowledge ever working in data science, this is almost a tautological statement by _definition of "standard error,"_ (at least for two-tailed distributions, I think,) even if different statistical distributions _define "standard error" differently in practice_, which is perfectly acceptable. Admittedly, this might not be appropriate for t-tests, for example, but the trick is that the standard terminology is more broadly self-consistent than the specific method of calculation appropriate to the particular sample distribution, which is still up to the submitting member.

However, _please_ continue to raise any and all theoretical concerns you have. It improves the quality of the product. And, I've tagged you as a reviewer, Sarah, exactly in case I'm wrong, and we can correct it.