### PR TITLE
#550: Remove redundant API call, for platform names

### DIFF
--- a/src/views/Submission.js
+++ b/src/views/Submission.js
@@ -706,6 +706,7 @@ class Submission extends React.Component {
                     this.handleSortPlatforms(res.data.data)
                     const platforms = [...res.data.data]
                     this.handleTrimPlatforms(submission, platforms)
+                    console.log(platforms)
 
                     let defPlatform = ''
                     if (platforms.length) {
@@ -721,15 +722,6 @@ class Submission extends React.Component {
                         this.handleTrimTags(submission, tags)
 
                         this.setState({ isRequestFailed: false, requestFailedMessage: '', allTagNames: res.data.data, tagNames: tags })
-
-                        const platformNamesRoute = config.api.getUriPrefix() + '/platform/names'
-                        axios.get(platformNamesRoute)
-                          .then(res => {
-                            this.setState({ isRequestFailed: false, requestFailedMessage: '', allPlatformNames: res.data.data, platformNames: res.data.data })
-                          })
-                          .catch(err => {
-                            this.setState({ isRequestFailed: true, requestFailedMessage: ErrorHandler(err) })
-                          })
                       })
                       .catch(err => {
                         this.setState({ isRequestFailed: true, requestFailedMessage: ErrorHandler(err) })

--- a/src/views/Submission.js
+++ b/src/views/Submission.js
@@ -706,7 +706,6 @@ class Submission extends React.Component {
                     this.handleSortPlatforms(res.data.data)
                     const platforms = [...res.data.data]
                     this.handleTrimPlatforms(submission, platforms)
-                    console.log(platforms)
 
                     let defPlatform = ''
                     if (platforms.length) {


### PR DESCRIPTION
Per #550, about alphabetization, there was a redundant API call to retrieve platforms after the sorting step had already taken place. This removes it, which should also slightly reduce loading time for certain view data.