### PR TITLE
#556: Fix edit 'flicker'

### DIFF
--- a/src/views/Submission.js
+++ b/src/views/Submission.js
@@ -352,7 +352,7 @@ class Submission extends React.Component {
   handleOnClickEditResult (resultId) {
     for (let i = 0; i < this.state.item.results.length; i++) {
       if (this.state.item.results[i].id === resultId) {
-        const result = this.state.item.results[i]
+        const result = { ...this.state.item.results[i] }
         result.submissionId = this.state.item.id
         if (result.task.id !== undefined) {
           result.task = result.task.id


### PR DESCRIPTION
In submission detail view, when editing a result, we need to compare the result DTO "row" with the set of all results DTOs and populate the modal view. However, the code we use to do this edits the row in-place, by reference. If we clone the row (by copying its values) before editing it, we can still make the necessary comparisons and updates, but the original row is left unaltered, in-place.