### PR TITLE
#578: Mobile portrait view charts

### DIFF
--- a/src/components/SotaChartMobile.js
+++ b/src/components/SotaChartMobile.js
@@ -1,0 +1,172 @@
+// SotaChartMobile.js
+// from https://www.d3-graph-gallery.com/graph/scatter_basic.html
+// and https://betterprogramming.pub/react-d3-plotting-a-line-chart-with-tooltips-ed41a4c31f4f
+
+import React from 'react'
+import { Chart, LinearScale, TimeScale, PointElement, LineElement, ScatterController, Tooltip, Legend } from 'chart.js'
+import { LineWithErrorBarsChart } from 'chartjs-chart-error-bars'
+import 'chartjs-adapter-moment'
+
+class SotaChartMobile extends React.Component {
+  constructor (props) {
+    super(props)
+
+    this.percentileZ = this.percentileZ.bind(this)
+    const z95 = this.percentileZ(0.95)
+
+    Chart.register([LinearScale, TimeScale, PointElement, LineElement, ScatterController, Tooltip, Legend])
+    Chart.defaults.font.size = 16
+
+    const data = this.props.data
+    const sotaData = data.length ? [data[0]] : []
+    for (let i = 1; i < data.length; i++) {
+      if (this.props.isLowerBetter) {
+        if (data[i].value <= sotaData[sotaData.length - 1].value) {
+          sotaData.push(data[i])
+        }
+      } else {
+        if (data[i].value >= sotaData[sotaData.length - 1].value) {
+          sotaData.push(data[i])
+        }
+      }
+    }
+
+    this.state = {
+      data: {
+        datasets: [{
+          type: 'scatter',
+          label: 'All (±95% CI, when provided)',
+          labels: this.props.data.map((obj, index) => obj.method + (obj.platform ? ' | ' + obj.platform : '')),
+          backgroundColor: 'rgb(0, 0, 0)',
+          borderColor: 'rgb(0, 0, 0)',
+          data: this.props.data.map((obj, index) => {
+            return {
+              label: obj.method + (obj.platform ? ' | ' + obj.platform : ''),
+              isShowLabel: false,
+              x: obj.label,
+              y: obj.value,
+              yMin: obj.standardError ? (obj.value - obj.standardError * z95) : undefined,
+              yMax: obj.standardError ? (obj.value + obj.standardError * z95) : undefined
+            }
+          })
+        },
+        {
+          type: 'scatterWithErrorBars',
+          label: '[HIDE LABEL] 1',
+          backgroundColor: 'rgb(128, 128, 128)',
+          borderColor: 'rgb(128, 128, 128)',
+          data: this.props.data.map((obj, index) => {
+            return {
+              x: obj.label,
+              y: obj.value,
+              yMin: obj.standardError ? (obj.value - obj.standardError * z95) : undefined,
+              yMax: obj.standardError ? (obj.value + obj.standardError * z95) : undefined
+            }
+          })
+        },
+        {
+          type: 'line',
+          label: 'State-of-the-art',
+          labels: sotaData.map((obj, index) => obj.method + (obj.platform ? '\n' + obj.platform : '')),
+          backgroundColor: 'rgb(60, 210, 249)',
+          borderColor: 'rgb(60, 210, 249)',
+          data: sotaData.map((obj, index) => {
+            return {
+              label: obj.method + (obj.platform ? '\n' + obj.platform : ''),
+              isShowLabel: true,
+              x: obj.label,
+              y: obj.value
+            }
+          })
+        }]
+      },
+      options: {
+        scales: {
+          x: {
+            type: 'time',
+            title: {
+              display: true,
+              text: this.props.xLabel ? this.props.xLabel : 'Time'
+            },
+            time: {
+              displayFormats: {
+                millisecond: 'YYYY-MM-DD HH:MM:ss.SSS',
+                second: 'YYYY-MM-DD HH:MM:ss',
+                minute: 'YYYY-MM-DD HH:MM',
+                hour: 'YYYY-MM-DD HH',
+                day: 'YYYY-MM-DD',
+                week: 'YYYY-MM-DD',
+                month: 'YYYY-MM',
+                quarter: 'YYYY-MM',
+                year: 'YYYY'
+              }
+            }
+          },
+          y: {
+            title: {
+              display: true,
+              text: this.props.yLabel ? this.props.yLabel : 'Metric value'
+            }
+          }
+        },
+        plugins: {
+          tooltip: {
+            callbacks: {
+              label: function (ctx) {
+                let label = ctx.dataset.labels[ctx.dataIndex]
+                label += ' (' + ctx.parsed.y + ')'
+                return label
+              }
+            },
+            filter: function (tooltipItem) {
+              const type = tooltipItem.dataset.type
+              return (type === 'scatter')
+            }
+          },
+          datalabels: {
+            display: false
+          },
+          legend: {
+            labels: {
+              filter: function (item, chart) {
+                // Logic to remove a particular legend item goes here
+                return !item.text.includes('[HIDE LABEL]')
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  componentDidMount () {
+    (() => new LineWithErrorBarsChart(document.getElementById('sota-chart-mobile-canvas').getContext('2d'), {
+      data: this.state.data,
+      options: this.state.options
+    }))()
+  }
+
+  // See https://stackoverflow.com/questions/36575743/how-do-i-convert-probability-into-z-score#answer-36577594
+  percentileZ (p) {
+    if (p < 0.5) return -this.percentileZ(1 - p)
+
+    if (p > 0.92) {
+      if (p === 1) return Infinity
+      const r = Math.sqrt(-Math.log(1 - p))
+      return (((2.3212128 * r + 4.8501413) * r - 2.2979648) * r - 2.7871893) /
+               ((1.6370678 * r + 3.5438892) * r + 1)
+    }
+    p -= 0.5
+    const r = p * p
+    return p * (((-25.4410605 * r + 41.3911977) * r - 18.6150006) * r + 2.5066282) /
+             ((((3.1308291 * r - 21.0622410) * r + 23.0833674) * r - 8.4735109) * r + 1)
+  }
+
+  // TODO: "key={Math.random()}" is a work-around to make the chart update on input properties change,
+  // See https://github.com/reactchartjs/react-chartjs-2/issues/90#issuecomment-409105108
+  render () {
+    return <canvas id='sota-chart-mobile-canvas' key={Math.random()} />
+  }
+}
+
+export default SotaChartMobile

--- a/src/views/Task.js
+++ b/src/views/Task.js
@@ -18,6 +18,7 @@ import { FacebookShareButton, TwitterShareButton, FacebookIcon, TwitterIcon } fr
 import moment from 'moment'
 import { parse } from 'json2csv'
 import Commento from '../components/Commento'
+import SotaChartMobile from '../components/SotaChartMobile'
 
 library.add(faEdit)
 
@@ -302,7 +303,7 @@ class Task extends React.Component {
                 </div>
                 <SotaChart data={this.state.chartData[this.state.chartKey]} xLabel='Time' yLabel={this.state.chartKey} isLowerBetter={this.state.isLowerBetterDict[this.state.chartKey]} key={Math.random()} />
               </div>
-              <div className='sota-chart-message'><i>(Your screen is too small for charts! If you're on mobile, try landscape view.)</i></div>
+              <div className='sota-chart-message'><SotaChartMobile data={this.state.chartData[this.state.chartKey]} xLabel='Time' yLabel={this.state.chartKey} isLowerBetter={this.state.isLowerBetterDict[this.state.chartKey]} key={Math.random()} /></div>
             </div>}
           <div className='row'>
             <div className='col-md-12'>


### PR DESCRIPTION
We _cannot_ display the entire information of the desktop SOTA charts will the same detail in mobile _portrait_ view, nor should we try. However, we _can_ strip the chart of all data point labels and rely on the interactive tooltips to communicate the same information, in so narrow of a space.

I suspect we'll iterate on this again, but it's a good step in the right direction. We'll let the team try it, and they can follow up with additional feedback on #578.