### PR TITLE
#529: Sticky footer fixes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -25,7 +25,7 @@
 }
 
 .footer-shim {
-  height: 128px;
+  height: 384px;
 }
 
 textarea {

--- a/src/components/simple-react-footer/SimpleReactFooter.js
+++ b/src/components/simple-react-footer/SimpleReactFooter.js
@@ -20,6 +20,8 @@ class SimpleReactFooter extends React.Component {
     this.handleHoverFocus = this.handleHoverFocus.bind(this)
     this.handleHoverFocusLeave = this.handleHoverFocusLeave.bind(this)
     this.handleStopPropagation = this.handleStopPropagation.bind(this)
+
+    window.addEventListener('resize', this.handleOnClick)
   }
 
   async timeout (delay) {
@@ -28,7 +30,8 @@ class SimpleReactFooter extends React.Component {
 
   handleOnClick () {
     if (this.state.bottom !== 0) {
-      this.setState({ isHover: true, bottom: 0, arrowOpacity: 0.0 })
+      const height = this.divElement.clientHeight
+      this.setState({ isHover: true, bottom: 0, arrowOpacity: 0.0, height })
     } else {
       this.handleHoverFocusLeave()
     }
@@ -36,9 +39,10 @@ class SimpleReactFooter extends React.Component {
 
   async handleHoverFocus () {
     this.setState({ isHover: true })
-    await this.timeout(333)
+    await this.timeout(500)
     if (this.state.isHover) {
-      this.setState({ bottom: 0, arrowOpacity: 0.0 })
+      const height = this.divElement.clientHeight
+      this.setState({ bottom: 0, arrowOpacity: 0.0, height })
     }
   }
 


### PR DESCRIPTION
People continue to have issues with the sticky footer. Several steps have been taken to alleviate the issue:

1. The empty space at the bottom of all pages has been increased significantly, to completely avoid overlap between footer and content.
2. The delay before the footer reacts to hover has been increased from 1/3 of a second to 1/2 of a second.
3. The footer now responds to viewport window resizing, (but it has to return to the "neutral" position of pop-up, first, to measure its own height and position, before collapsing again).

Please consider that we might not want a sticky footer _at all_. We have conflicting design requirements, here, in terms of _why_ we want the sticky footer in the first place (i.e., always occupy a portion of the screen with legal and social information) and what we _don't_ want the sticky footer to do (i.e., take up screen space and distract from the primary app content).