### PR TITLE
#578: For charts, smaller fonts, center-align text, SOTA is strictly improvement

### DIFF
--- a/src/components/SotaChart.js
+++ b/src/components/SotaChart.js
@@ -16,17 +16,17 @@ class SotaChart extends React.Component {
     const z95 = this.percentileZ(0.95)
 
     Chart.register([LinearScale, LogarithmicScale, TimeScale, PointElement, LineElement, ScatterController, Tooltip, Legend, ChartDataLabels])
-    Chart.defaults.font.size = 16
+    Chart.defaults.font.size = 12
 
     const data = this.props.data
     const sotaData = data.length ? [data[0]] : []
     for (let i = 1; i < data.length; i++) {
       if (this.props.isLowerBetter) {
-        if (data[i].value <= sotaData[sotaData.length - 1].value) {
+        if (data[i].value < sotaData[sotaData.length - 1].value) {
           sotaData.push(data[i])
         }
       } else {
-        if (data[i].value >= sotaData[sotaData.length - 1].value) {
+        if (data[i].value > sotaData[sotaData.length - 1].value) {
           sotaData.push(data[i])
         }
       }
@@ -135,7 +135,7 @@ class SotaChart extends React.Component {
             }
           },
           datalabels: {
-            align: 'right',
+            align: 'center',
             formatter: function (value, context) {
               return value.isShowLabel ? value.label : ''
             }

--- a/src/components/SotaChartMobile.js
+++ b/src/components/SotaChartMobile.js
@@ -15,17 +15,17 @@ class SotaChartMobile extends React.Component {
     const z95 = this.percentileZ(0.95)
 
     Chart.register([LinearScale, LogarithmicScale, TimeScale, PointElement, LineElement, ScatterController, Tooltip, Legend])
-    Chart.defaults.font.size = 16
+    Chart.defaults.font.size = 12
 
     const data = this.props.data
     const sotaData = data.length ? [data[0]] : []
     for (let i = 1; i < data.length; i++) {
       if (this.props.isLowerBetter) {
-        if (data[i].value <= sotaData[sotaData.length - 1].value) {
+        if (data[i].value < sotaData[sotaData.length - 1].value) {
           sotaData.push(data[i])
         }
       } else {
-        if (data[i].value >= sotaData[sotaData.length - 1].value) {
+        if (data[i].value > sotaData[sotaData.length - 1].value) {
           sotaData.push(data[i])
         }
       }


### PR DESCRIPTION
Per #578, charts have been made more readable. We use a (slightly) smaller font, center-align labels, and modify the SOTA line calculation slightly to only include the _first data point in time_ to reach a SOTA result.

For the SOTA calculation, firstly, this is conceptually more correct: for two or more identical results at SOTA level, SOTA was established for the _earliest_ one. However, incidentally and conveniently, this makes us less likely to be forced to render two SOTA labels at the exact same height on the graph and close in time, improving the readability of the charts.

![Screenshot from 2022-06-22 12-19-13](https://user-images.githubusercontent.com/2674693/175084296-54ce420b-9848-4698-8397-5f2138a746ee.png)
.