### PR TITLE
#558: Use react-router consistently throughout app

### DIFF
--- a/src/MainRouter.js
+++ b/src/MainRouter.js
@@ -61,10 +61,9 @@ const MainRouter = (props) => {
         </Route>
         <Route
           exact
-          path='/Login/AddSubmission'
-        >
-          {props.isLoggedIn ? <Redirect to='/AddSubmission' /> : <LogIn onLogin={props.onLogin} nextLocation='/AddSubmission' />}
-        </Route>
+          path='/Login/:next'
+          render={p => props.isLoggedIn ? <Redirect to={'/' + decodeURIComponent(p.match.params.next)} /> : <LogIn {...props} next={p.match.params.next} />}
+        />
         <Route
           exact
           path='/Login'
@@ -73,10 +72,9 @@ const MainRouter = (props) => {
         </Route>
         <Route
           exact
-          path='/Register/AddSubmission'
-        >
-          {props.isLoggedIn ? <Redirect to='/AddSubmission' /> : <Register onLogin={props.onLogin} nextLocation='/AddSubmission' />}
-        </Route>
+          path='/Register/:next'
+          render={p => props.isLoggedIn ? <Redirect to={'/' + decodeURIComponent(p.match.params.next)} /> : <Register {...props} />}
+        />
         <Route
           exact
           path='/Register'

--- a/src/components/CategoryItemBox.js
+++ b/src/components/CategoryItemBox.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import Tooltip from 'react-bootstrap/Tooltip'
+import { Link } from 'react-router-dom'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faHeart, faExternalLinkAlt, faChartLine } from '@fortawesome/free-solid-svg-icons'
@@ -30,7 +31,7 @@ class CategoryItemBox extends React.Component {
         <td>
           <div className='row submission'>
             <div className='col-12 col-md-9'>
-              <a href={this.state.detailUrl}>
+              <Link to={this.state.detailUrl}>
                 {this.props.type !== 'tag' && this.props.item.description &&
                   <div>
                     <div className='submission-heading'>{this.props.item.name}</div>
@@ -38,7 +39,7 @@ class CategoryItemBox extends React.Component {
                   </div>}
                 {(this.props.type === 'tag' || !this.props.item.description) &&
                   <div className='submission-heading-only'>{this.props.item.name}</div>}
-              </a>
+              </Link>
             </div>
             <div className='col-4 col-md-1'>
               <OverlayTrigger placement='top' overlay={props => <Tooltip {...props}>Count of results, with {this.props.type}</Tooltip>}>

--- a/src/views/LogIn.js
+++ b/src/views/LogIn.js
@@ -60,12 +60,6 @@ class LogIn extends React.Component {
     axios.post(config.api.getUriPrefix() + '/login', request)
       .then(res => {
         this.props.onLogin()
-
-        if (this.props.nextLocation) {
-          this.context.history.push(this.props.nextLocation)
-        } else {
-          this.context.history.pop()
-        }
       })
       .catch(err => {
         this.setState({ isRequestFailed: true, requestFailedMessage: ErrorHandler(err) })
@@ -106,7 +100,7 @@ class LogIn extends React.Component {
             </div>
           </div>
         </form>
-        <Link to={this.props.nextLocation ? '/Register' + this.props.nextLocation : '/Register'}>Create a new account</Link><br />
+        <Link to={this.props.next ? '/Register/' + this.props.next : '/Register'}>Create a new account</Link><br />
         <Link to='/Forgot'>Forgot username/password?</Link>
       </div>
     )

--- a/src/views/LogIn.js
+++ b/src/views/LogIn.js
@@ -63,6 +63,8 @@ class LogIn extends React.Component {
 
         if (this.props.nextLocation) {
           this.context.history.push(this.props.nextLocation)
+        } else {
+          this.context.history.pop()
         }
       })
       .catch(err => {

--- a/src/views/Method.js
+++ b/src/views/Method.js
@@ -177,7 +177,7 @@ class Method extends React.Component {
             <div className='row'>
               <div className='col-md-12'>
                 <div className='submission-description'>
-                  <b>Parent method:</b> <a href={'/Method/' + this.state.item.parentMethod.id}>{this.state.item.parentMethod.name}</a>
+                  <b>Parent method:</b> <Link to={'/Method/' + this.state.item.parentMethod.id}>{this.state.item.parentMethod.name}</Link>
                 </div>
               </div>
               <br />
@@ -198,11 +198,12 @@ class Method extends React.Component {
                     data={this.state.item.childMethods
                       ? this.state.item.childMethods.map(row => ({
                           key: row.id,
-                          name: row.name
+                          name: row.name,
+                          props: this.props
                         }))
                       : []}
                     onRow={(record) => ({
-                      onClick () { window.location.href = '/Method/' + record.key }
+                      onClick () { record.props.history.push('/Method/' + record.key) }
                     })}
                     tableLayout='auto'
                     rowClassName='link'
@@ -240,11 +241,12 @@ class Method extends React.Component {
                       key: row.id,
                       name: row.name,
                       createdAt: new Date(row.createdAt).toLocaleDateString('en-US'),
-                      upvoteCount: row.upvoteCount || 0
+                      upvoteCount: row.upvoteCount || 0,
+                      props: this.props
                     }))
                   : []}
                 onRow={(record) => ({
-                  onClick () { window.location.href = '/Submission/' + record.key }
+                  onClick () { record.props.history.push('/Submission/' + record.key) }
                 })}
                 tableLayout='auto'
                 rowClassName='link'

--- a/src/views/Method.js
+++ b/src/views/Method.js
@@ -56,7 +56,7 @@ class Method extends React.Component {
 
   handleEditModalDone () {
     if (!this.props.isLoggedIn) {
-      window.location.href = '/Login'
+      this.props.history.push('/Login')
     }
 
     const reqBody = {

--- a/src/views/Platform.js
+++ b/src/views/Platform.js
@@ -417,7 +417,7 @@ class Platform extends React.Component {
             <div className='row'>
               <div className='col-md-12'>
                 <div className='submission-description'>
-                  <b>Parent platform:</b> <a href={'/Platform/' + this.state.item.parentPlatform.id}>{this.state.item.parentPlatform.name}</a>
+                  <b>Parent platform:</b> <Link to={'/Platform/' + this.state.item.parentPlatform.id}>{this.state.item.parentPlatform.name}</Link>
                 </div>
               </div>
               <br />

--- a/src/views/Register.js
+++ b/src/views/Register.js
@@ -96,10 +96,6 @@ class Register extends React.Component {
     axios.post(config.api.getUriPrefix() + '/register', this.state)
       .then(res => {
         this.props.onLogin()
-
-        if (this.props.nextLocation) {
-          this.context.history.push(this.props.nextLocation)
-        }
       })
       .catch(err => {
         this.setState({ isRequestFailed: true, requestFailedMessage: ErrorHandler(err) })

--- a/src/views/Submission.js
+++ b/src/views/Submission.js
@@ -836,10 +836,11 @@ class Submission extends React.Component {
                 data={this.state.item.tasks.map(row =>
                   ({
                     key: row.id,
-                    name: row.name
+                    name: row.name,
+                    props: this.props
                   }))}
                 onRow={(record) => ({
-                  onClick () { window.location.href = '/Task/' + record.key }
+                  onClick () { record.props.history.push('/Task/' + record.key) }
                 })}
                 tableLayout='auto'
                 rowClassName='link'
@@ -873,10 +874,11 @@ class Submission extends React.Component {
                 data={this.state.item.methods.map(row =>
                   ({
                     key: row.id,
-                    name: row.name
+                    name: row.name,
+                    props: this.props
                   }))}
                 onRow={(record) => ({
-                  onClick () { window.location.href = '/Method/' + record.key }
+                  onClick () { record.props.history.push('/Method/' + record.key) }
                 })}
                 tableLayout='auto'
                 rowClassName='link'

--- a/src/views/Submission.js
+++ b/src/views/Submission.js
@@ -1063,7 +1063,7 @@ class Submission extends React.Component {
           <Modal.Body>
             {(this.state.modalMode === 'Login') &&
               <span>
-                Please <Link to='/Login'>login</Link> before editing.
+                Please <Link to={'/Login/' + encodeURIComponent('Submission/' + this.props.match.params.id)}>login</Link> before editing.
               </span>}
             {(this.state.modalMode === 'Method') &&
               <span>
@@ -1331,7 +1331,7 @@ class Submission extends React.Component {
           <Modal.Body>
             {(this.state.modalMode === 'Login') &&
               <span>
-                Please <Link to='/Login'>login</Link> before editing.
+                Please <Link to={'/Login/' + encodeURIComponent('Submission/' + this.props.match.params.id)}>login</Link> before editing.
               </span>}
             {(this.state.modalMode === 'Task') &&
               <span>
@@ -1453,7 +1453,7 @@ class Submission extends React.Component {
           <Modal.Body>
             {(this.state.modalMode === 'Login') &&
               <span>
-                Please <Link to='/Login'>login</Link> before {this.state.modalTextMode === 'Moderation' ? 'filing a report' : 'editing'}.
+                Please <Link to={'/Login/' + encodeURIComponent('Submission/' + this.props.match.params.id)}>login</Link> before {this.state.modalTextMode === 'Moderation' ? 'filing a report' : 'editing'}.
               </span>}
             {(this.state.modalMode !== 'Login') &&
               <span>

--- a/src/views/Submission.js
+++ b/src/views/Submission.js
@@ -214,7 +214,7 @@ class Submission extends React.Component {
           window.alert('Error: ' + ErrorHandler(err) + '\nSorry! Check your connection and login status, and try again.')
         })
     } else {
-      window.location.href = '/Login'
+      this.props.history.push('/Login')
     }
   }
 
@@ -235,7 +235,7 @@ class Submission extends React.Component {
           window.alert('Error: ' + ErrorHandler(err) + '\nSorry! Check your connection and login status, and try again.')
         })
     } else {
-      window.location.href = '/Login'
+      this.props.history.push('/Login')
     }
   }
 
@@ -256,7 +256,7 @@ class Submission extends React.Component {
           window.alert('Error: ' + ErrorHandler(err) + '\nSorry! Check your connection and login status, and try again.')
         })
     } else {
-      window.location.href = '/Login'
+      this.props.history.push('/Login')
     }
   }
 
@@ -276,7 +276,7 @@ class Submission extends React.Component {
           window.alert('Error: ' + ErrorHandler(err) + '\nSorry! Check your connection and login status, and try again.')
         })
     } else {
-      window.location.href = '/Login'
+      this.props.history.push('/Login')
     }
   }
 
@@ -301,7 +301,7 @@ class Submission extends React.Component {
           window.alert('Error: ' + ErrorHandler(err) + '\nSorry! Check your connection and login status, and try again.')
         })
     } else {
-      window.location.href = '/Login'
+      this.props.history.push('/Login')
     }
   }
 
@@ -315,7 +315,7 @@ class Submission extends React.Component {
           window.alert('Error: ' + ErrorHandler(err) + '\nSorry! Check your connection and login status, and try again.')
         })
     } else {
-      window.location.href = '/Login'
+      this.props.history.push('/Login')
     }
     event.preventDefault()
   }

--- a/src/views/Task.js
+++ b/src/views/Task.js
@@ -66,7 +66,7 @@ class Task extends React.Component {
 
   handleEditModalDone () {
     if (!this.props.isLoggedIn) {
-      window.location.href = '/Login'
+      this.props.history.push('/Login')
     }
 
     const reqBody = {

--- a/src/views/Task.js
+++ b/src/views/Task.js
@@ -186,7 +186,8 @@ class Task extends React.Component {
             methodName: row.methodName,
             metricName: row.metricName,
             metricValue: row.metricValue,
-            tableDate: row.evaluatedAt ? new Date(row.evaluatedAt).toLocaleDateString() : new Date(row.createdAt).toLocaleDateString()
+            tableDate: row.evaluatedAt ? new Date(row.evaluatedAt).toLocaleDateString() : new Date(row.createdAt).toLocaleDateString(),
+            props: this.props
           }))
         this.setState({ results: results, resultsJson: resultsJson })
         this.sliceChartData(results)
@@ -348,7 +349,7 @@ class Task extends React.Component {
             <div className='row'>
               <div className='col-md-12'>
                 <div className='submission-description'>
-                  <b>Parent task:</b> <a href={'/Task/' + this.state.item.parentTask.id}>{this.state.item.parentTask.name}</a>
+                  <b>Parent task:</b><Link to={'/Task/' + this.state.item.parentTask.id}>{this.state.item.parentTask.name}</Link>
                 </div>
               </div>
               <br />
@@ -404,7 +405,7 @@ class Task extends React.Component {
                   }]}
                   data={this.state.resultsJson}
                   onRow={(record) => ({
-                    onClick () { window.location.href = '/Submission/' + record.submissionId }
+                    onClick () { record.props.history.push('/Submission/' + record.key) }
                   })}
                   tableLayout='auto'
                   rowClassName='link'
@@ -441,11 +442,12 @@ class Task extends React.Component {
                           key: row.id,
                           name: row.name,
                           createdAt: new Date(row.createdAt).toLocaleDateString('en-US'),
-                          upvoteCount: row.upvoteCount || 0
+                          upvoteCount: row.upvoteCount || 0,
+                          props: this.props
                         }))
                       : []}
                     onRow={(record) => ({
-                      onClick () { window.location.href = '/Submission/' + record.key }
+                      onClick () { record.props.history.push('/Submission/' + record.key) }
                     })}
                     tableLayout='auto'
                     rowClassName='link'


### PR DESCRIPTION
For #558, you're aware from the research on the issue that you shared with me that `react-router` has a "stack" of views that the user has navigated since arriving on a URL with the `<MainRouter>`. Within the context of `<MainRouter>`, ("any view inside its opening and closing tags," basically,) Clicking `<Link>` tags and triggering programmatic manipulation of the router history will redirect the user to other views, and push their old views on the "stack."

We had "abused" this functionality, previously, in part because I personally didn't see an easy way to make it work with our `<Table>` component dependency. It turns out, it's not a perfectly clean solution, but we can append `this.props` from the containing component class to table data rows, to access the router history within `<Table>`. Once we get _every_ point of user navigation in the router history, then returning from login should just be a matter of "popping the history stack" by one level upon successful login.

You'll also notice that navigation from all these links I changed will feel "smoother," because they're actually using "single-page application" ("SPA") routing properly, now. As a result, the browser doesn't have to refresh, at all, to route to the next view to which the user attempts to navigate. (This might be hard to understand in text, but you'll probably see exactly what I mean once we get this up on the production environment and you click some links. It will feel "smoother" or "seamless," because the browser never actually needs to refresh to load the next view.)