### PR TITLE
#461: Chart date formats

### DIFF
--- a/src/components/SotaChart.js
+++ b/src/components/SotaChart.js
@@ -6,6 +6,7 @@ import React from 'react'
 import { Chart, LinearScale, LogarithmicScale, TimeScale, PointElement, LineElement, ScatterController, Tooltip, Legend } from 'chart.js'
 import ChartDataLabels from 'chartjs-plugin-datalabels'
 import { LineWithErrorBarsChart } from 'chartjs-chart-error-bars'
+import moment from 'moment'
 import 'chartjs-adapter-moment'
 
 class SotaChart extends React.Component {
@@ -100,10 +101,10 @@ class SotaChart extends React.Component {
             },
             time: {
               displayFormats: {
-                millisecond: 'YYYY-MM-DD HH:MM:ss.SSS',
-                second: 'YYYY-MM-DD HH:MM:ss',
-                minute: 'YYYY-MM-DD HH:MM',
-                hour: 'YYYY-MM-DD HH',
+                millisecond: 'YYYY-MM-DD',
+                second: 'YYYY-MM-DD',
+                minute: 'YYYY-MM-DD',
+                hour: 'YYYY-MM-DD',
                 day: 'YYYY-MM-DD',
                 week: 'YYYY-MM-DD',
                 month: 'YYYY-MM',
@@ -123,6 +124,9 @@ class SotaChart extends React.Component {
         plugins: {
           tooltip: {
             callbacks: {
+              title: function(ctx) {
+                return moment(ctx[0].parsed.x).format('YYYY-MM-DD')
+              },
               label: function (ctx) {
                 let label = ctx.dataset.labels[ctx.dataIndex]
                 label += ' (' + ctx.parsed.y + ')'

--- a/src/components/SotaChartMobile.js
+++ b/src/components/SotaChartMobile.js
@@ -5,6 +5,7 @@
 import React from 'react'
 import { Chart, LinearScale, LogarithmicScale, TimeScale, PointElement, LineElement, ScatterController, Tooltip, Legend } from 'chart.js'
 import { LineWithErrorBarsChart } from 'chartjs-chart-error-bars'
+import moment from 'moment'
 import 'chartjs-adapter-moment'
 
 class SotaChartMobile extends React.Component {
@@ -94,10 +95,10 @@ class SotaChartMobile extends React.Component {
             },
             time: {
               displayFormats: {
-                millisecond: 'YYYY-MM-DD HH:MM:ss.SSS',
-                second: 'YYYY-MM-DD HH:MM:ss',
-                minute: 'YYYY-MM-DD HH:MM',
-                hour: 'YYYY-MM-DD HH',
+                millisecond: 'YYYY-MM-DD',
+                second: 'YYYY-MM-DD',
+                minute: 'YYYY-MM-DD',
+                hour: 'YYYY-MM-DD',
                 day: 'YYYY-MM-DD',
                 week: 'YYYY-MM-DD',
                 month: 'YYYY-MM',
@@ -117,6 +118,9 @@ class SotaChartMobile extends React.Component {
         plugins: {
           tooltip: {
             callbacks: {
+              title: function(ctx) {
+                return moment(ctx[0].parsed.x).format('YYYY-MM-DD')
+              },
               label: function (ctx) {
                 let label = ctx.dataset.labels[ctx.dataIndex]
                 label += ' (' + ctx.parsed.y + ')'

--- a/src/views/AddSubmission.js
+++ b/src/views/AddSubmission.js
@@ -141,20 +141,6 @@ class AddSubmission extends React.Component {
             <div className='col-md-3' />
           </div>
           <FormFieldRow
-            inputName='name' inputType='text' label='Submission Name'
-            validatorMessage={requiredFieldMissingError}
-            onChange={this.handleOnChange}
-            validRegex={nonblankRegex}
-            value={this.state.name}
-          />
-          <div className='row'>
-            <div className='col-md-3' />
-            <div className='col-md-6'>
-              <b>The submission name must be unique.</b>
-            </div>
-            <div className='col-md-3' />
-          </div>
-          <FormFieldRow
             inputName='contentUrl' inputType='text' label='Content URL'
             validatorMessage={requiredFieldMissingError}
             onChange={this.handleOnChange}
@@ -165,6 +151,20 @@ class AddSubmission extends React.Component {
             <div className='col-md-3' />
             <div className='col-md-6'>
               <b>The external content URL points to the full content of the submission.<br />(This could be a link to arXiv, for example.)<br /><i>This cannot be changed after hitting "Submit."</i></b>
+            </div>
+            <div className='col-md-3' />
+          </div>
+          <FormFieldRow
+            inputName='name' inputType='text' label='Submission Name'
+            validatorMessage={requiredFieldMissingError}
+            onChange={this.handleOnChange}
+            validRegex={nonblankRegex}
+            value={this.state.name}
+          />
+          <div className='row'>
+            <div className='col-md-3' />
+            <div className='col-md-6'>
+              <b>The submission name must be unique.</b>
             </div>
             <div className='col-md-3' />
           </div>


### PR DESCRIPTION
Per #461, artificial time stamp information, below the date level, has been removed from task charts.

Also, we noted in passing that content URL should be collected on the top line of the submission workflow, since this automatically populates the title and description.