### PR TITLE
#460: 'responsive' Charts.js option and 'min-height' styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -285,6 +285,10 @@ form > .row > label {
   }
 }
 
+#sota-chart-mobile-canvas {
+  min-height: 300px;
+}
+
 /** Simple generic styling */
 
 .text-center {

--- a/src/components/SotaChartMobile.js
+++ b/src/components/SotaChartMobile.js
@@ -81,6 +81,8 @@ class SotaChartMobile extends React.Component {
         }]
       },
       options: {
+        responsive: true,
+        maintainAspectRatio: false,
         scales: {
           x: {
             type: 'time',


### PR DESCRIPTION
For mobile view charts, this enables Charts.js' `responsive` option and sets a minimum chart height.
![mobile_charts](https://user-images.githubusercontent.com/2674693/175392145-da5bad04-e2a0-4258-b4b2-a392fbead334.png)
![mobile_charts_landscape](https://user-images.githubusercontent.com/2674693/175392532-b42d04f1-4c44-404c-a6de-05bbe9a2d257.png)

