### PR TITLE
#613: Populate default parentTask ID, to create new tasks

### DIFF
--- a/src/components/FormFieldRow.js
+++ b/src/components/FormFieldRow.js
@@ -77,10 +77,10 @@ const FormFieldRow = (props) => {
       {props.imageUrl
         ? <Button variant='primary' onClick={() => setImagePreviewUrl(value)}>Preview</Button>
         : <FormFieldValidator invalid={!isValid} className='col-md-3' message={props.validatorMessage} />}
-    {imagePreviewUrl && isValid &&
-      <FormFieldWideRow className='text-center'>
-        <img src={imagePreviewUrl} alt='Submission thumbnail preview' className='submission-image' />
-      </FormFieldWideRow>}
+      {imagePreviewUrl && isValid &&
+        <FormFieldWideRow className='text-center'>
+          <img src={imagePreviewUrl} alt='Submission thumbnail preview' className='submission-image' />
+        </FormFieldWideRow>}
     </div>
   )
 }

--- a/src/components/FormFieldSelectRow.js
+++ b/src/components/FormFieldSelectRow.js
@@ -13,7 +13,13 @@ const FormFieldSelectRow = (props) => {
     commonOptions = options
   }
 
-  const [value, setValue] = useState(props.defaultValue ? props.defaultValue : '')
+  const [value, setValue] = useState(props.value
+    ? props.value
+    : (props.defaultValue
+        ? props.defaultValue
+        : options.length && !props.isNullDefault
+          ? options[0].id
+          : ''))
 
   const handleOnFieldChange = (event) => {
     // For a regular input field, read field name and value from the event.

--- a/src/views/Submission.js
+++ b/src/views/Submission.js
@@ -392,6 +392,11 @@ class Submission extends React.Component {
         if (!task.description) {
           task.description = ''
         }
+        if (!task.parentTask) {
+          const options = this.state.allTaskNames
+          options.sort((a, b) => (a.top < b.top) ? 1 : -1)
+          task.parentTask = options.filter(x => x.top === 1)[0].id
+        }
         axios.post(config.api.getUriPrefix() + '/task', task)
           .then(res => {
             window.location.reload()


### PR DESCRIPTION
Turns out that our issue for #613 specifically happens with only the "Applications" task category, if and when the selection is left default by intention. This fixes it, though.