### PR TITLE
#621: Centralize Regex definitions

### DIFF
--- a/src/components/ValidationRegex.js
+++ b/src/components/ValidationRegex.js
@@ -1,0 +1,28 @@
+const dateRegex = /^\d{4}-\d{2}-\d{2}$/
+const intRegex = /^([+-]?[1-9]\d*|0)$/
+const metricValueRegex = /(^[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)$)|([+-]?\d(\.\d+)?[Ee][+-]?\d+)/
+const nonblankRegex = /(.|\s)*\S(.|\s)*/
+const numberRegex = /^[+-]?([0-9]+\.?[0-9]*|\.[0-9]+)$/
+const passwordValidRegex = /.{12,}/
+const sampleSizeRegex = /^[0-9]+$/
+const standardErrorRegex = /^[0-9]+([.][0-9]*)?|[.][0-9]+$/
+const urlValidRegex = new RegExp('^(https?:\\/\\/)?' + // protocol
+      '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
+      '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
+      '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
+      '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
+      '(\\#[-a-z\\d_]*)?$', 'i') // fragment locator
+const usernameValidRegex = /^(?!\s*$).+/
+
+module.exports = {
+  dateRegex,
+  intRegex,
+  metricValueRegex,
+  nonblankRegex,
+  numberRegex,
+  passwordValidRegex,
+  sampleSizeRegex,
+  standardErrorRegex,
+  urlValidRegex,
+  usernameValidRegex
+}

--- a/src/views/AddSubmission.js
+++ b/src/views/AddSubmission.js
@@ -13,12 +13,11 @@ import { faPlus, faTrash } from '@fortawesome/free-solid-svg-icons'
 import FormFieldWideRow from '../components/FormFieldWideRow'
 import ViewHeader from '../components/ViewHeader'
 import { Redirect } from 'react-router-dom'
+import { nonblankRegex, urlValidRegex } from '../components/ValidationRegex'
 
 library.add(faPlus, faTrash)
 
 const requiredFieldMissingError = 'Required field.'
-
-const nonblankRegex = /(.|\s)*\S(.|\s)*/
 
 class AddSubmission extends React.Component {
   constructor (props) {
@@ -42,16 +41,11 @@ class AddSubmission extends React.Component {
     this.handleOnSubmit = this.handleOnSubmit.bind(this)
     this.handleOnClickAddTag = this.handleOnClickAddTag.bind(this)
     this.handleOnClickRemoveTag = this.handleOnClickRemoveTag.bind(this)
+    this.validURL = this.validURL.bind(this)
   }
 
   validURL (str) {
-    const pattern = new RegExp('^(https?:\\/\\/)?' + // protocol
-      '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
-      '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
-      '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
-      '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
-      '(\\#[-a-z\\d_]*)?$', 'i') // fragment locator
-    return !!pattern.test(str)
+    return !!urlValidRegex.test(str)
   }
 
   handleOnChange (field, value) {

--- a/src/views/Forgot.js
+++ b/src/views/Forgot.js
@@ -7,9 +7,9 @@ import ErrorHandler from '../components/ErrorHandler'
 import FormFieldAlertRow from '../components/FormFieldAlertRow'
 import FormFieldWideRow from '../components/FormFieldWideRow'
 import ViewHeader from '../components/ViewHeader'
+import { usernameValidRegex } from '../components/ValidationRegex'
 
 const usernameMissingError = 'Username cannot be blank.'
-const usernameValidRegex = /^(?!\s*$).+/
 
 class Forgot extends React.Component {
   constructor (props) {

--- a/src/views/LogIn.js
+++ b/src/views/LogIn.js
@@ -9,11 +9,10 @@ import ErrorHandler from '../components/ErrorHandler'
 import FormFieldAlertRow from '../components/FormFieldAlertRow'
 import FormFieldWideRow from '../components/FormFieldWideRow'
 import ViewHeader from '../components/ViewHeader'
+import { usernameValidRegex } from '../components/ValidationRegex'
 
 const usernameMissingError = 'Username cannot be blank.'
 const passwordInvalidError = 'Password is too short.'
-
-const usernameValidRegex = /^(?!\s*$).+/
 
 class LogIn extends React.Component {
   constructor (props) {

--- a/src/views/Password.js
+++ b/src/views/Password.js
@@ -8,12 +8,11 @@ import PasswordVisibleControlRow from '../components/PasswordVisibleControlRow'
 import FormFieldAlertRow from '../components/FormFieldAlertRow'
 import FormFieldWideRow from '../components/FormFieldWideRow'
 import ViewHeader from '../components/ViewHeader'
+import { passwordValidRegex } from '../components/ValidationRegex'
 
 const passwordInvalidError = 'Password is too short.'
 const passwordMismatchError = 'Confirm does not match.'
 const passwordRequiredError = 'Required'
-
-const passwordValidRegex = /.{12,}/
 
 class Password extends React.Component {
   constructor (props) {

--- a/src/views/Platform.js
+++ b/src/views/Platform.js
@@ -14,11 +14,9 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import FormFieldWideRow from '../components/FormFieldWideRow'
 import TooltipTrigger from '../components/TooltipTrigger'
 import SocialShareIcons from '../components/SocialShareIcons'
+import { intRegex, nonblankRegex, numberRegex } from '../components/ValidationRegex'
 
 const defaultRegex = /.+/
-const nameRegex = /.{1,}/
-const intRegex = /^([+-]?[1-9]\d*|0)$/
-const numberRegex = /^[+-]?([0-9]+\.?[0-9]*|\.[0-9]+)$/
 // bool is handled by checkbox FormFieldRow
 // datetime is handled by date/time picker FormFieldRow
 // date is handled by date-only picker FormFieldRow
@@ -656,7 +654,7 @@ class Platform extends React.Component {
                               inputType='text'
                               label='Name'
                               onChange={(field, value) => this.handleOnChange('property', field, value)}
-                              validRegex={nameRegex}
+                              validRegex={nonblankRegex}
                               tooltip='Short name of new property'
                             /><br />
                             <FormFieldRow

--- a/src/views/Recover.js
+++ b/src/views/Recover.js
@@ -7,13 +7,11 @@ import ErrorHandler from '../components/ErrorHandler'
 import FormFieldAlertRow from '../components/FormFieldAlertRow'
 import FormFieldWideRow from '../components/FormFieldWideRow'
 import ViewHeader from '../components/ViewHeader'
+import { passwordValidRegex, usernameValidRegex } from '../components/ValidationRegex'
 
 const usernameMissingError = 'Username cannot be blank.'
 const passwordInvalidError = 'Password is too short.'
 const passwordMismatchError = 'Confirm does not match.'
-
-const usernameValidRegex = /^(?!\s*$).+/
-const passwordValidRegex = /.{12,}/
 
 class Recover extends React.Component {
   constructor (props) {

--- a/src/views/Submission.js
+++ b/src/views/Submission.js
@@ -18,13 +18,10 @@ import Commento from '../components/Commento'
 import FormFieldAlertRow from '../components/FormFieldAlertRow'
 import FormFieldWideRow from '../components/FormFieldWideRow'
 import SocialShareIcons from '../components/SocialShareIcons'
+import { dateRegex, metricValueRegex, nonblankRegex, standardErrorRegex } from '../components/ValidationRegex'
 
 library.add(faEdit, faExternalLinkAlt, faHeart, faPlus, faTrash, faMobileAlt, faStickyNote, faSuperscript)
 
-const dateRegex = /^\d{4}-\d{2}-\d{2}$/
-const nameRegex = /.{1,}/
-const metricValueRegex = /(^[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)$)|([+-]?\d(\.\d+)?[Ee][+-]?\d+)/
-const standardErrorRegex = /^[0-9]+([.][0-9]*)?|[.][0-9]+$/
 const sampleSizeRegex = /^[0-9]+$/
 
 class Submission extends React.Component {
@@ -602,7 +599,7 @@ class Submission extends React.Component {
 
     if (this.state.modalMode === 'Task') {
       if (this.state.showAccordion) {
-        if (!nameRegex.test(this.state.task.name)) {
+        if (!nonblankRegex.test(this.state.task.name)) {
           return false
         }
       } else if (!this.state.taskId) {
@@ -610,7 +607,7 @@ class Submission extends React.Component {
       }
     } else if (this.state.modalMode === 'Method') {
       if (this.state.showAccordion) {
-        if (!nameRegex.test(this.state.method.name)) {
+        if (!nonblankRegex.test(this.state.method.name)) {
           return false
         }
       } else if (!this.state.methodId) {
@@ -618,14 +615,14 @@ class Submission extends React.Component {
       }
     } else if (this.state.modalMode === 'Platform') {
       if (this.state.showAccordion) {
-        if (!nameRegex.test(this.state.platform.name)) {
+        if (!nonblankRegex.test(this.state.platform.name)) {
           return false
         }
       } else if (!this.state.platformId) {
         return false
       }
     } else if (this.state.modalMode === 'Result') {
-      if (!nameRegex.test(this.state.result.metricName)) {
+      if (!nonblankRegex.test(this.state.result.metricName)) {
         return false
       }
       if (!metricValueRegex.test(this.state.result.metricValue)) {
@@ -1068,7 +1065,7 @@ class Submission extends React.Component {
                           inputType='text'
                           label='Name'
                           onChange={(field, value) => this.handleOnChange('method', field, value)}
-                          validRegex={nameRegex}
+                          validRegex={nonblankRegex}
                           tooltip='Short name of new method'
                         /><br />
                         <FormFieldRow
@@ -1123,7 +1120,7 @@ class Submission extends React.Component {
                           inputType='text'
                           label='Name'
                           onChange={(field, value) => this.handleOnChange('task', field, value)}
-                          validRegex={nameRegex}
+                          validRegex={nonblankRegex}
                           tooltip='Short name of new task'
                         /><br />
                         <FormFieldRow
@@ -1178,7 +1175,7 @@ class Submission extends React.Component {
                           inputType='text'
                           label='Name'
                           onChange={(field, value) => this.handleOnChange('platform', field, value)}
-                          validRegex={nameRegex}
+                          validRegex={nonblankRegex}
                           tooltip='Short name of new platform'
                         /><br />
                         <FormFieldRow
@@ -1240,7 +1237,7 @@ class Submission extends React.Component {
                   inputName='metricName' label='Metric name'
                   value={this.state.result.metricName}
                   onChange={(field, value) => this.handleOnChange('result', field, value)}
-                  validRegex={nameRegex}
+                  validRegex={nonblankRegex}
                   options={this.state.metricNames}
                   tooltip='The name of the measure of performance, for this combination of task and method, for this submission'
                 /><br />
@@ -1290,7 +1287,7 @@ class Submission extends React.Component {
                 <FormFieldTypeaheadRow
                   inputName='tag' label='Tag'
                   onChange={(field, value) => this.handleOnChange('', field, value)}
-                  validRegex={nameRegex}
+                  validRegex={nonblankRegex}
                   options={this.state.tagNames.map(item => item.name)}
                   tooltip='A "tag" can be any string that loosely categorizes a submission by relevant topic.'
                 /><br />


### PR DESCRIPTION
Per #621, by centralizing the definition of our regular expressions for form field input validation, we ensure that the same intended validation conditions are maintained across all instances of usage. (Also, `Regex()` initialization and use can be expensive, and this design might improve performance in certain cases of usage.)