### PR TITLE
#728: Prepopulate 'new' modal from typeahead

### DIFF
--- a/src/components/FormFieldTypeaheadRow.js
+++ b/src/components/FormFieldTypeaheadRow.js
@@ -10,6 +10,9 @@ const FormFieldTypeaheadRow = (props) => {
   const typeahead = useRef(null)
   const coalescedId = props.inputId ? props.inputId : props.inputName
 
+  // See https://stackoverflow.com/questions/4059147/check-if-a-variable-is-a-string-in-javascript#answer-17772086
+  const isString = (x) => (Object.prototype.toString.call(x) === '[object String]')
+
   const handleOnFieldChange = (input) => {
     // For a regular input field, read field name and value from the event.
     const fieldName = props.inputName
@@ -17,7 +20,7 @@ const FormFieldTypeaheadRow = (props) => {
     if (props.validRegex) {
       setIsValid(props.validRegex.test(fieldValue))
     }
-    if (fieldValue !== value) {
+    if (isString(fieldValue) && (fieldValue !== value)) {
       if (props.onChange) {
         props.onChange(fieldName, fieldValue)
       }
@@ -32,7 +35,7 @@ const FormFieldTypeaheadRow = (props) => {
     if (props.validRegex) {
       setIsValid(props.validRegex.test(fieldValue))
     }
-    if (fieldValue !== value) {
+    if (isString(fieldValue) && (fieldValue !== value)) {
       if (props.onBlur) {
         props.onBlur(fieldName, fieldValue)
       }
@@ -86,7 +89,7 @@ const FormFieldTypeaheadRow = (props) => {
         disabled={props.disabled}
       />
       {(!!props.onClickAdd && !props.onClickNew) && <Button variant='primary' className='submission-ref-button' onClick={handleOnButtonClick} disabled={props.disabled || !value}>{props.buttonLabel ? props.buttonLabel : 'Add'}</Button>}
-      {!!props.onClickNew && <Button variant='primary' className='submission-ref-button' onClick={props.onClickNew} disabled={props.disabled}>New</Button>}
+      {!!props.onClickNew && <Button variant='primary' className='submission-ref-button' onClick={() => props.onClickNew(value)} disabled={props.disabled}>New</Button>}
       {(!props.onClickAdd && !props.onClickNew) && <div className='col col-md-3'><Suspense fallback={<div>Loading...</div>}><FormFieldValidator invalid={!isValid} message={props.validatorMessage} /></Suspense></div>}
     </div>
   )

--- a/src/components/SubmissionRefsAddModal.js
+++ b/src/components/SubmissionRefsAddModal.js
@@ -18,7 +18,7 @@ const SubmissionRefsAddModal = (props) => {
   const [showAccordion, setShowAccordion] = useState(!!props.isNewOnly)
   const [item, setItem] = useState({
     id: props.filteredNames.length ? props.filteredNames[0].id : 0,
-    name: '',
+    name: props.refName ? props.refName : '',
     fullName: '',
     parent: '',
     description: '',
@@ -26,9 +26,18 @@ const SubmissionRefsAddModal = (props) => {
   })
 
   useEffect(() => {
-    item.submissions = props.submissionId.toString()
-    setItem(item)
-  }, [props.submissionId, item])
+    const nItem = { ...item }
+    const submissions = props.submissionId.toString()
+    let isChanged = nItem.submissions !== submissions
+    nItem.submissions = submissions
+    if (props.refName) {
+      isChanged |= nItem.name !== props.refName
+      nItem.name = props.refName
+    }
+    if (isChanged) {
+      setItem(nItem)
+    }
+  }, [props.submissionId, props.refName, item])
 
   const key = props.modalMode === 'Task'
     ? 'task'
@@ -178,6 +187,7 @@ const SubmissionRefsAddModal = (props) => {
                       inputName='name'
                       inputType='text'
                       label='Name'
+                      value={item.name}
                       onChange={handleOnChangeName}
                       validRegex={nonblankRegex}
                       tooltip={`Short name of new ${key}`}

--- a/src/views/AddSubmission.js
+++ b/src/views/AddSubmission.js
@@ -222,11 +222,11 @@ class AddSubmission extends React.Component {
     }
   }
 
-  handleOnClickNewTask () {
+  handleOnClickNewTask (name) {
     if (!this.state.submission.id) {
-      this.handleOnSubmit(null, true, () => this.setState({ showAddRefsModal: true, modalMode: 'Task', allNames: this.state.taskNames }))
+      this.handleOnSubmit(null, true, () => this.setState({ showAddRefsModal: true, modalMode: 'Task', allNames: this.state.taskNames, refName: name }))
     } else {
-      this.setState({ showAddRefsModal: true, modalMode: 'Task', allNames: this.state.taskNames })
+      this.setState({ showAddRefsModal: true, modalMode: 'Task', allNames: this.state.taskNames, refName: name })
     }
   }
 
@@ -249,11 +249,11 @@ class AddSubmission extends React.Component {
     }
   }
 
-  handleOnClickNewMethod () {
+  handleOnClickNewMethod (name) {
     if (!this.state.submission.id) {
-      this.handleOnSubmit(null, true, () => this.setState({ showAddRefsModal: true, modalMode: 'Method', allNames: this.state.methodNames }))
+      this.handleOnSubmit(null, true, () => this.setState({ showAddRefsModal: true, modalMode: 'Method', allNames: this.state.methodNames, refName: name }))
     } else {
-      this.setState({ showAddRefsModal: true, modalMode: 'Method', allNames: this.state.methodNames })
+      this.setState({ showAddRefsModal: true, modalMode: 'Method', allNames: this.state.methodNames, refName: name })
     }
   }
 
@@ -276,11 +276,11 @@ class AddSubmission extends React.Component {
     }
   }
 
-  handleOnClickNewPlatform () {
+  handleOnClickNewPlatform (name) {
     if (!this.state.submission.id) {
-      this.handleOnSubmit(null, true, () => this.setState({ showAddRefsModal: true, modalMode: 'Platform', allNames: this.state.platformNames }))
+      this.handleOnSubmit(null, true, () => this.setState({ showAddRefsModal: true, modalMode: 'Platform', allNames: this.state.platformNames, refName: name }))
     } else {
-      this.setState({ showAddRefsModal: true, modalMode: 'Platform', allNames: this.state.platformNames })
+      this.setState({ showAddRefsModal: true, modalMode: 'Platform', allNames: this.state.platformNames, refName: name })
     }
   }
 
@@ -565,6 +565,7 @@ class AddSubmission extends React.Component {
               show={this.state.showAddRefsModal}
               onHide={() => this.setState({ showAddRefsModal: false })}
               modalMode={this.state.modalMode}
+              refName={this.state.refName}
               submissionId={this.state.submission.id}
               allNames={this.state.allNames}
               filteredNames={this.state.allNames}


### PR DESCRIPTION
If text entered in the "typeahead" to add a taxonomy reference isn't found as an option, so the user clicks "New" to add it, then the same text is used to prepopulate the "New" option modal.