### PR TITLE
#742: Typeahead for parent refs

### DIFF
--- a/src/components/FormFieldTypeaheadRow.js
+++ b/src/components/FormFieldTypeaheadRow.js
@@ -25,6 +25,7 @@ const FormFieldTypeaheadRow = (props) => {
         props.onChange(fieldName, fieldValue)
       }
       setValue(fieldValue)
+      setIsValid(true)
     }
   }
 
@@ -40,6 +41,7 @@ const FormFieldTypeaheadRow = (props) => {
         props.onBlur(fieldName, fieldValue)
       }
       setValue(fieldValue)
+      setIsValid(true)
     }
   }
 

--- a/src/components/FormFieldTypeaheadRow.js
+++ b/src/components/FormFieldTypeaheadRow.js
@@ -16,8 +16,8 @@ const FormFieldTypeaheadRow = (props) => {
   const handleOnFieldChange = (input) => {
     // For a regular input field, read field name and value from the event.
     const fieldName = props.inputName
-    const fieldValue = input
-    if (props.validRegex) {
+    const fieldValue = (input && input.name) ? input.name : input
+    if (isString(fieldValue) && props.validRegex) {
       setIsValid(props.validRegex.test(fieldValue))
     }
     if (isString(fieldValue) && (fieldValue !== value)) {
@@ -32,8 +32,8 @@ const FormFieldTypeaheadRow = (props) => {
   const handleOnFieldBlur = (input) => {
     // For a regular input field, read field name and value from the event.
     const fieldName = props.inputName
-    const fieldValue = input
-    if (props.validRegex) {
+    const fieldValue = (input && input.name) ? input.name : input
+    if (isString(fieldValue) && props.validRegex) {
       setIsValid(props.validRegex.test(fieldValue))
     }
     if (isString(fieldValue) && (fieldValue !== value)) {

--- a/src/components/SubmissionRefsAddModal.js
+++ b/src/components/SubmissionRefsAddModal.js
@@ -65,19 +65,13 @@ const SubmissionRefsAddModal = (props) => {
       return
     }
 
-    console.log(value)
-    console.log(props.allNames)
-    console.log(item.name)
-
     const fn = props.allNames.find(f => f.name === value)
     if (fn) {
-      console.log('Hit!')
       item.parent = fn.id
       if (props.modalMode === 'Task') {
         setIsValid(!!(item.name))
       }
     } else {
-      console.log('Fail!')
       item.parent = undefined
       if (value || (props.modalMode === 'Task')) {
         setIsValid(false)

--- a/src/components/SubmissionRefsAddModal.js
+++ b/src/components/SubmissionRefsAddModal.js
@@ -68,9 +68,7 @@ const SubmissionRefsAddModal = (props) => {
     const fn = props.allNames.find(f => f.name === value)
     if (fn) {
       item.parent = fn.id
-      if (props.modalMode === 'Task') {
-        setIsValid(!!(item.name))
-      }
+      setIsValid(!!(item.name))
     } else {
       item.parent = undefined
       if (value || (props.modalMode === 'Task')) {

--- a/src/components/SubmissionRefsAddModal.js
+++ b/src/components/SubmissionRefsAddModal.js
@@ -10,7 +10,6 @@ import { nonblankRegex } from './ValidationRegex'
 import ErrorHandler from './ErrorHandler'
 import FormFieldTypeaheadRow from './FormFieldTypeaheadRow'
 const FormFieldRow = React.lazy(() => import('./FormFieldRow'))
-const FormFieldSelectRow = React.lazy(() => import('./FormFieldSelectRow'))
 
 library.add(faPlus)
 
@@ -51,6 +50,42 @@ const SubmissionRefsAddModal = (props) => {
     setShowAccordion(!showAccordion)
   }
 
+  const handleOnSelectParent = (nItem) => {
+    if (showAccordion || !nItem) {
+      return
+    }
+
+    item.parent = nItem.id
+    setIsValid(!!(item.name))
+    setItem(item)
+  }
+
+  const handleOnChangeParent = (field, value) => {
+    if (!showAccordion) {
+      return
+    }
+
+    console.log(value)
+    console.log(props.allNames)
+    console.log(item.name)
+
+    const fn = props.allNames.find(f => f.name === value)
+    if (fn) {
+      console.log('Hit!')
+      item.parent = fn.id
+      if (props.modalMode === 'Task') {
+        setIsValid(!!(item.name))
+      }
+    } else {
+      console.log('Fail!')
+      item.parent = undefined
+      if (value || (props.modalMode === 'Task')) {
+        setIsValid(false)
+      }
+    }
+    setItem(item)
+  }
+
   const handleOnSelectRef = (nItem) => {
     if (showAccordion || !nItem) {
       setIsValid(false)
@@ -84,21 +119,12 @@ const SubmissionRefsAddModal = (props) => {
 
     item.name = value
     setItem(item)
-    setIsValid(nonblankRegex.test(item.name))
+    setIsValid(!!(item.name))
   }
 
   const handleReset = () => {
     setShowAccordion(false)
     setIsValid(!!item.name)
-  }
-
-  const handleOnChangeParent = (field, value) => {
-    if (!showAccordion) {
-      return
-    }
-
-    item.parent = value
-    setItem(item)
   }
 
   const handleOnChange = (field, value) => {
@@ -219,12 +245,13 @@ const SubmissionRefsAddModal = (props) => {
                       onChange={handleOnChange}
                       tooltip={`Long name of new ${key}`}
                     /><br />
-                    <FormFieldSelectRow
+                    <FormFieldTypeaheadRow
                       inputName={`parent${props.modalMode}`}
-                      label={`Parent ${key}<br/>(if any)`}
-                      isNullDefault
+                      label={`Parent ${key}` + (props.modalMode === 'Task' ? '(required)' : '<br/>(if any)')} labelKey='name'
                       options={props.allNames}
+                      onSelect={handleOnSelectParent}
                       onChange={handleOnChangeParent}
+                      validRegex={(item.parent || isValid) ? undefined : /a^/}
                       tooltip={`Optionally, the new ${key} is a sub-${key} of a "parent" ${key}.`}
                     /><br />
                     <FormFieldRow

--- a/src/views/Task.js
+++ b/src/views/Task.js
@@ -160,7 +160,7 @@ class Task extends React.Component {
       ({
         key: row.id,
         name: row.submissionName,
-        submissionId: task.submissions.find(e => e.name === row.submissionName).id,
+        submissionId: task.submissions.find(e => e.name === row.submissionName) ? task.submissions.find(e => e.name === row.submissionName).id : 0,
         platformName: row.platformName,
         methodName: row.methodName,
         metricName: row.metricName,


### PR DESCRIPTION
This adds a "type-ahead" components for submission reference (i.e. task/method/platform) parents.