### PR TITLE
#747: No top level task keys in modal

### DIFF
--- a/src/components/SubmissionRefsAddModal.js
+++ b/src/components/SubmissionRefsAddModal.js
@@ -253,7 +253,7 @@ const SubmissionRefsAddModal = (props) => {
                     /><br />
                     <FormFieldTypeaheadRow
                       inputName={`parent${props.modalMode}`}
-                      label={`Parent ${key}` + (props.modalMode === 'Task' ? '(required)' : '<br/>(if any)')} labelKey='name'
+                      label={`Parent ${key}` + (props.modalMode === 'Task' ? '' : '<br/>(if any)')} labelKey='name'
                       options={props.allNames}
                       onSelect={handleOnSelectParent}
                       onChange={handleOnChangeParent}

--- a/src/views/Submission.js
+++ b/src/views/Submission.js
@@ -120,6 +120,7 @@ class Submission extends React.Component {
     this.handleOnChange = this.handleOnChange.bind(this)
     this.handleSortNames = this.handleSortNames.bind(this)
     this.handleTrimTasks = this.handleTrimTasks.bind(this)
+    this.handleTrimParentTasks = this.handleTrimParentTasks.bind(this)
     this.handleTrimMethods = this.handleTrimMethods.bind(this)
     this.handleTrimPlatforms = this.handleTrimPlatforms.bind(this)
     this.handleTrimTags = this.handleTrimTags.bind(this)
@@ -398,12 +399,22 @@ class Submission extends React.Component {
   }
 
   handleTrimTasks (submission, tasks) {
+    this.handleTrimParentTasks(tasks)
     for (let i = 0; i < submission.tasks.length; i++) {
       for (let j = 0; j < tasks.length; j++) {
         if (submission.tasks[i].id === tasks[j].id) {
           tasks.splice(j, 1)
           break
         }
+      }
+    }
+  }
+
+  handleTrimParentTasks (tasks) {
+    for (let j = 0; j < tasks.length; j++) {
+      if (tasks[j].top) {
+        tasks.splice(j, 1)
+        --j
       }
     }
   }


### PR DESCRIPTION
This closes #747, by removing top-level tasks as an option for submission references.