### PR TITLE
#751: Detect and redirect users to existing submission drafts

### DIFF
--- a/src/views/About.js
+++ b/src/views/About.js
@@ -9,8 +9,7 @@ const About = () => {
             <p>
               Make transparent, accessible benchmarks available to everyone in the quantum computing community.
             </p>
-            <iframe title='Metriq: the open source platform for community driven quantum benchmarks' width='420' height='315' src='https://www.youtube.com/embed/tg6Q5fnw2EE'>
-            </iframe>
+            <iframe title='Metriq: the open source platform for community driven quantum benchmarks' width='420' height='315' src='https://www.youtube.com/embed/tg6Q5fnw2EE' />
           </div>
           <br />
           <h1 className='text-center'>About</h1>

--- a/src/views/AddSubmission.js
+++ b/src/views/AddSubmission.js
@@ -138,6 +138,10 @@ class AddSubmission extends React.Component {
     if (field === 'contentUrl') {
       axios.post(config.api.getUriPrefix() + '/pagemetadata', { url: value.trim() })
         .then(res => {
+          const edid = res.data.data.ExistingDraftId
+          if (edid && (window.confirm('You have an existing draft with this URL. Press "OK" to be redirected to this draft.') === true)) {
+            this.props.history.push('/Submission/' + edid)
+          }
           this.setState({ name: res.data.data.og.title, description: res.data.data.og.description.replace(/\n/g, ' '), isAlreadyInDatabase: res.data.data.isAlreadyInDatabase, isValidated: false })
         })
         .catch(err => {

--- a/src/views/FAQ.js
+++ b/src/views/FAQ.js
@@ -27,8 +27,7 @@ const FAQ = () => {
             <p>
               A metriq <b>"submission"</b> can be an arXiv preprint, GitHub repository, or links to peer reviewed and published articles.
             </p>
-            <iframe title='How to make a submission on Metriq: the platform for community driven quantum benchmarks' width='420' height='315' src='https://www.youtube.com/embed/XjLeutpo3v0'>
-            </iframe>
+            <iframe title='How to make a submission on Metriq: the platform for community driven quantum benchmarks' width='420' height='315' src='https://www.youtube.com/embed/XjLeutpo3v0' />
             <p>
               A submission can present or utilize one of more <b>"methods"</b> by which they accomplish one or more <b>"tasks"</b>, which are workloads of interest.
             </p>


### PR DESCRIPTION
Per #751, there's a much simpler solution than retrofitting the "Add Submission" workflow to fill with the old draft: by the same logic that would _detect_ an existing draft, just give the user the option to automatically redirect to the draft page, if it exists.