### PR TITLE
#781: Accept Twitter handles with or without '@' character

### DIFF
--- a/src/views/Register.js
+++ b/src/views/Register.js
@@ -17,7 +17,7 @@ const passwordMismatchError = 'Confirm does not match.'
 const usernameValidRegex = /^(?!\s*$).+/
 const emailValidRegex = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
 const passwordValidRegex = /.{12,}/
-const twitterHandleValidRegex = /^$|^@[A-Za-z0-9_]{1,15}$/
+const twitterHandleValidRegex = /^@?[A-Za-z0-9_]{1,15}$/
 
 class Register extends React.Component {
   constructor (props) {


### PR DESCRIPTION
Per issue #781, after a user had an issue with signup, the Twitter handle field now accepts inputs with and without a leading `@` character.