### PR TITLE
#793: Prepopulate result date (from arXiv API)

### DIFF
--- a/src/components/ResultsAddModal.js
+++ b/src/components/ResultsAddModal.js
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import React, { useState, Suspense } from 'react'
+import React, { useState, Suspense, useEffect } from 'react'
 import { Button, Modal } from 'react-bootstrap'
 import config from '../config'
 import ErrorHandler from './ErrorHandler'
@@ -13,6 +13,15 @@ const ResultsAddModal = (props) => {
   const [isUpdated, setIsUpdated] = useState(false)
   const [result, setResult] = useState(props.result)
   const [submission, setSubmission] = useState({})
+  const [key, setKey] = useState(Math.random())
+
+  useEffect(() => {
+    if (!result.evaluatedAt) {
+      result.evaluatedAt = props.evaluatedAt
+      setResult(result)
+      setKey(Math.random())
+    }
+  }, [props.evaluatedAt, result, setResult, setKey])
 
   if (!isUpdated && props.show) {
     setIsUpdated(true)
@@ -90,7 +99,7 @@ const ResultsAddModal = (props) => {
     }
     result.circuitDepth = result.circuitDepth ? parseInt(result.circuitDepth) : null
     if (!result.evaluatedAt) {
-      result.evaluatedDate = new Date()
+      result.evaluatedAt = (new Date()).toISOString().split('T')[0]
     } else if (!dateRegex.test(result.evaluatedAt)) {
       window.alert('Error: "Evaluated at" is not a date.')
       return
@@ -206,6 +215,7 @@ const ResultsAddModal = (props) => {
             /><br />
             <FormFieldRow
               inputName='evaluatedAt' inputType='date' label='Evaluated'
+              key={key}
               value={result.evaluatedAt}
               validRegex={dateRegex}
               onChange={handleOnChange}

--- a/src/views/Submission.js
+++ b/src/views/Submission.js
@@ -39,6 +39,7 @@ class Submission extends React.Component {
       thumbnailUrl: '',
       codeUrl: '',
       supplementUrl: '',
+      evaluatedAt: '',
       item: { isUpvoted: false, upvotesCount: 0, tags: [], tasks: [], methods: [], platforms: [], results: [], user: [] },
       allNames: [],
       filteredNames: [],
@@ -74,7 +75,7 @@ class Submission extends React.Component {
         metricName: '',
         metricValue: 0,
         isHigherBetter: false,
-        evaluatedDate: new Date()
+        evaluatedAt: ''
       },
       task: {
         name: '',
@@ -342,7 +343,7 @@ class Submission extends React.Component {
       metricName: '',
       metricValue: 0,
       isHigherBetter: false,
-      evaluatedDate: new Date()
+      evaluatedAt: ''
     }
     this.setState({ result: result, showAddModal: true, modalMode: mode, showEditModal: mode === 'Login' })
   }
@@ -525,6 +526,17 @@ class Submission extends React.Component {
           vanityUrl = 'https://www.arxiv-vanity.com/' + urlTail
           urlTail = urlTail.substring(4)
           bibtexUrl = 'https://arxiv.org/bibtex/' + urlTail
+
+          axios.get('https://export.arxiv.org/api/query?id_list=' + urlTail)
+            .then((response) => {
+              const html = response.data.toString()
+              const noHead = html.split('<published>')[1]
+              const noTail = noHead.split('</published>')[0]
+              this.setState({ evaluatedAt: (new Date(noTail).toISOString().split('T')[0]) })
+            })
+            .catch(err => {
+              this.setState({ requestFailedMessage: ErrorHandler(err) })
+            })
         }
 
         // Just get the view populated as quickly as possible, before we "trim."
@@ -857,6 +869,7 @@ class Submission extends React.Component {
             onHide={this.handleHideAddModal}
             submission={this.state.item}
             result={this.state.result}
+            evaluatedAt={this.state.evaluatedAt}
             metricNames={this.state.metricNames}
             onAddOrEdit={this.handleModalResultAddNew}
           />


### PR DESCRIPTION
Per #793, it turns out that we never collect the arXiv publication date from users, but we can grab it directly from the arXiv API, to prepopulate the result entry modal.