### PR TITLE
#803: Homepage 'Top Submissions'

### DIFF
--- a/src/MainRouter.js
+++ b/src/MainRouter.js
@@ -59,7 +59,7 @@ const MainRouter = (props) => {
           exact
           path='/'
         >
-          <Tasks isLoggedIn={isLoggedIn} />
+          <Tasks isLoggedIn={isLoggedIn} isHomepage />
         </Route>
         <Route
           exact
@@ -95,7 +95,7 @@ const MainRouter = (props) => {
           exact
           path='/Tasks'
         >
-          <Tasks isLoggedIn={isLoggedIn} />
+          <Tasks isLoggedIn={isLoggedIn} isHomepage={false} />
         </Route>
         <Route
           exact

--- a/src/views/Tasks.js
+++ b/src/views/Tasks.js
@@ -10,11 +10,11 @@ import CategoryItemBox from '../components/CategoryItemBox'
 import FormFieldAlertRow from '../components/FormFieldAlertRow'
 import FormFieldWideRow from '../components/FormFieldWideRow'
 import ViewHeader from '../components/ViewHeader'
-import { sortCommon, sortPopular, sortAlphabetical } from '../components/SortFunctions'
+import { sortAlphabetical } from '../components/SortFunctions'
 import SotaChart from '../components/SotaChart'
 import { withRouter } from 'react-router-dom'
-import ViewSubHeader from '../components/ViewSubHeader'
 import SortingTable from '../components/SortingTable'
+import SubmissionBox from '../components/SubmissionBox'
 
 class Tasks extends React.Component {
   constructor (props) {
@@ -22,10 +22,12 @@ class Tasks extends React.Component {
     this.state = {
       isLoading: true,
       alphabetical: [],
-      popular: [],
-      common: [],
       allNames: [],
+      activeTab: 'Trending',
       featured: [],
+      trending: [],
+      popular: [],
+      latest: [],
       filterId: null,
       requestFailedMessage: '',
       topSubmitters: { weekly: [], monthly: [], allTime: [] }
@@ -33,6 +35,7 @@ class Tasks extends React.Component {
 
     this.handleOnFilter = this.handleOnFilter.bind(this)
     this.handleOnSelect = this.handleOnSelect.bind(this)
+    this.handleOnToggle = this.handleOnToggle.bind(this)
   }
 
   handleOnFilter (value) {
@@ -47,7 +50,35 @@ class Tasks extends React.Component {
     }
   }
 
+  handleOnToggle (tab) {
+    this.setState({ activeTab: tab })
+  }
+
   componentDidMount () {
+    axios.get(config.api.getUriPrefix() + '/submission/trending/0')
+      .then(res => {
+        this.setState({ trending: res.data.data.slice(0, 3) })
+      })
+      .catch(err => {
+        this.setState({ requestFailedMessage: ErrorHandler(err) })
+      })
+
+    axios.get(config.api.getUriPrefix() + '/submission/popular/0')
+      .then(res => {
+        this.setState({ popular: res.data.data.slice(0, 3) })
+      })
+      .catch(err => {
+        this.setState({ requestFailedMessage: ErrorHandler(err) })
+      })
+
+    axios.get(config.api.getUriPrefix() + '/submission/latest/0')
+      .then(res => {
+        this.setState({ latest: res.data.data.slice(0, 3) })
+      })
+      .catch(err => {
+        this.setState({ requestFailedMessage: ErrorHandler(err) })
+      })
+
     axios.get(config.api.getUriPrefix() + '/user/topSubmitters')
       .then(res => {
         const topSubmitters = res.data.data
@@ -66,17 +97,6 @@ class Tasks extends React.Component {
 
     axios.get(config.api.getUriPrefix() + '/task/submissionCount')
       .then(res => {
-        const common = [...res.data.data]
-        common.sort(sortCommon)
-        this.setState({
-          requestFailedMessage: '',
-          common: common
-        })
-
-        const popular = [...res.data.data]
-        popular.sort(sortPopular)
-        this.setState({ popular: popular })
-
         const alphabetical = res.data.data
         alphabetical.sort(sortAlphabetical)
         this.setState({ alphabetical: alphabetical, isLoading: false })
@@ -124,13 +144,140 @@ class Tasks extends React.Component {
   render () {
     return (
       <div id='metriq-main-content' className='container'>
+        {this.props.isHomepage &&
+          <span>
+            <ViewHeader>Top Submissions</ViewHeader>
+            <h5>Submissions are articles and code presenting research and tools for quantum technologies.</h5>
+            <Tabs id='top-submissions-tabs' activeKey={this.state.activeTab} onSelect={this.handleOnToggle}>
+              <Tab eventKey='Trending' title='Trending' className='metriq-nav-tab'>
+                {this.state.trending.map((item, index) =>
+                  <SubmissionBox
+                    item={item}
+                    key={index}
+                    isLoggedIn={this.props.isLoggedIn}
+                    isEditView={false}
+                    isUnderReview={!(item.approvedAt)}
+                    isDraft={!(item.publishedAt)}
+                  />)}
+              </Tab>
+              <Tab eventKey='Popular' title='Popular' className='metriq-nav-tab'>
+                {this.state.popular.map((item, index) =>
+                  <SubmissionBox
+                    item={item}
+                    key={index}
+                    isLoggedIn={this.props.isLoggedIn}
+                    isEditView={false}
+                    isUnderReview={!(item.approvedAt)}
+                    isDraft={!(item.publishedAt)}
+                  />)}
+              </Tab>
+              <Tab eventKey='Latest' title='Latest' className='metriq-nav-tab'>
+                {this.state.latest.map((item, index) =>
+                  <SubmissionBox
+                    item={item}
+                    key={index}
+                    isLoggedIn={this.props.isLoggedIn}
+                    isEditView={false}
+                    isUnderReview={!(item.approvedAt)}
+                    isDraft={!(item.publishedAt)}
+                  />)}
+              </Tab>
+            </Tabs>
+            <br />
+            <h5>Top Submitters</h5>
+            <Tabs id='top-submissions-tabs'>
+              <Tab eventKey='Weekly' title='Weekly' className='metriq-nav-tab'>
+                <div className='card'>
+                  <SortingTable
+                    columns={[
+                      {
+                        title: 'Name',
+                        key: 'username',
+                        width: 360
+                      },
+                      {
+                        title: 'Rank',
+                        key: 'rank',
+                        width: 80
+                      },
+                      {
+                        title: 'Submission Count',
+                        key: 'submissionsCount',
+                        width: 360
+                      }
+                    ]}
+                    data={this.state.topSubmitters.weekly}
+                    key={Math.random()}
+                    onRowClick={(record) => this.props.history.push('/User/' + record.id + '/Submissions')}
+                    tableLayout='auto'
+                    rowClassName='link'
+                  />
+                </div>
+              </Tab>
+              <Tab eventKey='Monthly' title='Monthly' className='metriq-nav-tab'>
+                <div className='card'>
+                  <SortingTable
+                    columns={[
+                      {
+                        title: 'Name',
+                        key: 'username',
+                        width: 360
+                      },
+                      {
+                        title: 'Rank',
+                        key: 'rank',
+                        width: 80
+                      },
+                      {
+                        title: 'Submission Count',
+                        key: 'submissionsCount',
+                        width: 360
+                      }
+                    ]}
+                    data={this.state.topSubmitters.monthly}
+                    key={Math.random()}
+                    onRowClick={(record) => this.props.history.push('/User/' + record.id + '/Submissions')}
+                    tableLayout='auto'
+                    rowClassName='link'
+                  />
+                </div>
+              </Tab>
+              <Tab eventKey='AllTime' title='All Time' className='metriq-nav-tab'>
+                <div className='card'>
+                  <SortingTable
+                    columns={[
+                      {
+                        title: 'Name',
+                        key: 'username',
+                        width: 360
+                      },
+                      {
+                        title: 'Rank',
+                        key: 'rank',
+                        width: 80
+                      },
+                      {
+                        title: 'Submission Count',
+                        key: 'submissionsCount',
+                        width: 360
+                      }
+                    ]}
+                    data={this.state.topSubmitters.allTime}
+                    key={Math.random()}
+                    onRowClick={(record) => this.props.history.push('/User/' + record.id + '/Submissions')}
+                    tableLayout='auto'
+                    rowClassName='link'
+                  />
+                </div>
+              </Tab>
+            </Tabs>
+            <br />
+            <br />
+          </span>}
         <ViewHeader>Tasks</ViewHeader>
         <h5>Tasks are workloads of interest performed on a quantum computer.</h5>
         <p>Search the task hierarchy to see charts of comparative performance across methods, see our submitter leader board and featured task charts, or click into the parent/child task hierarchy through top-level task categories.</p>
         <br />
-        <FormFieldWideRow className='centered-tabs'>
-          <ViewSubHeader>Categories</ViewSubHeader>
-        </FormFieldWideRow>
         <FormFieldWideRow className='search-bar'>
           <FormFieldTypeaheadRow
             options={this.state.allNames}
@@ -143,95 +290,6 @@ class Tasks extends React.Component {
             alignLabelRight
           />
         </FormFieldWideRow>
-        <br />
-        <h5>Top Submitters</h5>
-        <Tabs id='top-submissions-tabs'>
-          <Tab eventKey='Weekly' title='Weekly' className='metriq-nav-tab'>
-            <div className='card'>
-              <SortingTable
-                columns={[
-                  {
-                    title: 'Name',
-                    key: 'username',
-                    width: 360
-                  },
-                  {
-                    title: 'Rank',
-                    key: 'rank',
-                    width: 80
-                  },
-                  {
-                    title: 'Submission Count',
-                    key: 'submissionsCount',
-                    width: 360
-                  }
-                ]}
-                data={this.state.topSubmitters.weekly}
-                key={Math.random()}
-                onRowClick={(record) => this.props.history.push('/User/' + record.id + '/Submissions')}
-                tableLayout='auto'
-                rowClassName='link'
-              />
-            </div>
-          </Tab>
-          <Tab eventKey='Monthly' title='Monthly' className='metriq-nav-tab'>
-            <div className='card'>
-              <SortingTable
-                columns={[
-                  {
-                    title: 'Name',
-                    key: 'username',
-                    width: 360
-                  },
-                  {
-                    title: 'Rank',
-                    key: 'rank',
-                    width: 80
-                  },
-                  {
-                    title: 'Submission Count',
-                    key: 'submissionsCount',
-                    width: 360
-                  }
-                ]}
-                data={this.state.topSubmitters.monthly}
-                key={Math.random()}
-                onRowClick={(record) => this.props.history.push('/User/' + record.id + '/Submissions')}
-                tableLayout='auto'
-                rowClassName='link'
-              />
-            </div>
-          </Tab>
-          <Tab eventKey='AllTime' title='All Time' className='metriq-nav-tab'>
-            <div className='card'>
-              <SortingTable
-                columns={[
-                  {
-                    title: 'Name',
-                    key: 'username',
-                    width: 360
-                  },
-                  {
-                    title: 'Rank',
-                    key: 'rank',
-                    width: 80
-                  },
-                  {
-                    title: 'Submission Count',
-                    key: 'submissionsCount',
-                    width: 360
-                  }
-                ]}
-                data={this.state.topSubmitters.allTime}
-                key={Math.random()}
-                onRowClick={(record) => this.props.history.push('/User/' + record.id + '/Submissions')}
-                tableLayout='auto'
-                rowClassName='link'
-              />
-            </div>
-          </Tab>
-        </Tabs>
-        <br />
         <br />
         <FormFieldWideRow>
           <h5>Featured</h5>

--- a/src/views/Tasks.js
+++ b/src/views/Tasks.js
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import React from 'react'
+import React, { Suspense } from 'react'
 import config from './../config'
 import { Tabs, Tab } from 'react-bootstrap'
 import ErrorHandler from '../components/ErrorHandler'
@@ -14,7 +14,7 @@ import { sortAlphabetical } from '../components/SortFunctions'
 import SotaChart from '../components/SotaChart'
 import { withRouter } from 'react-router-dom'
 import SortingTable from '../components/SortingTable'
-import SubmissionBox from '../components/SubmissionBox'
+const SubmissionBox = React.lazy(() => import('../components/SubmissionBox'))
 
 class Tasks extends React.Component {
   constructor (props) {
@@ -148,41 +148,43 @@ class Tasks extends React.Component {
           <span>
             <ViewHeader>Top Submissions</ViewHeader>
             <h5>Submissions are articles and code presenting research and tools for quantum technologies.</h5>
-            <Tabs id='top-submissions-tabs' activeKey={this.state.activeTab} onSelect={this.handleOnToggle}>
-              <Tab eventKey='Trending' title='Trending' className='metriq-nav-tab'>
-                {this.state.trending.map((item, index) =>
-                  <SubmissionBox
-                    item={item}
-                    key={index}
-                    isLoggedIn={this.props.isLoggedIn}
-                    isEditView={false}
-                    isUnderReview={!(item.approvedAt)}
-                    isDraft={!(item.publishedAt)}
-                  />)}
-              </Tab>
-              <Tab eventKey='Popular' title='Popular' className='metriq-nav-tab'>
-                {this.state.popular.map((item, index) =>
-                  <SubmissionBox
-                    item={item}
-                    key={index}
-                    isLoggedIn={this.props.isLoggedIn}
-                    isEditView={false}
-                    isUnderReview={!(item.approvedAt)}
-                    isDraft={!(item.publishedAt)}
-                  />)}
-              </Tab>
-              <Tab eventKey='Latest' title='Latest' className='metriq-nav-tab'>
-                {this.state.latest.map((item, index) =>
-                  <SubmissionBox
-                    item={item}
-                    key={index}
-                    isLoggedIn={this.props.isLoggedIn}
-                    isEditView={false}
-                    isUnderReview={!(item.approvedAt)}
-                    isDraft={!(item.publishedAt)}
-                  />)}
-              </Tab>
-            </Tabs>
+            <Suspense fallback={<div>Loading...</div>}>
+              <Tabs id='top-submissions-tabs' activeKey={this.state.activeTab} onSelect={this.handleOnToggle}>
+                <Tab eventKey='Trending' title='Trending' className='metriq-nav-tab'>
+                  {this.state.trending.map((item, index) =>
+                    <SubmissionBox
+                      item={item}
+                      key={index}
+                      isLoggedIn={this.props.isLoggedIn}
+                      isEditView={false}
+                      isUnderReview={!(item.approvedAt)}
+                      isDraft={!(item.publishedAt)}
+                    />)}
+                </Tab>
+                <Tab eventKey='Popular' title='Popular' className='metriq-nav-tab'>
+                  {this.state.popular.map((item, index) =>
+                    <SubmissionBox
+                      item={item}
+                      key={index}
+                      isLoggedIn={this.props.isLoggedIn}
+                      isEditView={false}
+                      isUnderReview={!(item.approvedAt)}
+                      isDraft={!(item.publishedAt)}
+                    />)}
+                </Tab>
+                <Tab eventKey='Latest' title='Latest' className='metriq-nav-tab'>
+                  {this.state.latest.map((item, index) =>
+                    <SubmissionBox
+                      item={item}
+                      key={index}
+                      isLoggedIn={this.props.isLoggedIn}
+                      isEditView={false}
+                      isUnderReview={!(item.approvedAt)}
+                      isDraft={!(item.publishedAt)}
+                    />)}
+                </Tab>
+              </Tabs>
+            </Suspense>
             <br />
             <h5>Top Submitters</h5>
             <Tabs id='top-submissions-tabs'>


### PR DESCRIPTION
Per #803, @nathanshammah requested that we add the top 3 "trending"/"popular"/"latest" submissions to the homepage.

This works for the homepage, (proper,) but the design is becoming extremely "busy" as the _tasks_ page. Hence, when the user clicks the "Tasks" menu item, they see the same view _without_ top submissions and top submitters, in this PR.