### PR TITLE
#795: Add chart padding

### DIFF
--- a/src/components/SotaChart.js
+++ b/src/components/SotaChart.js
@@ -253,7 +253,8 @@ class SotaChart extends React.Component {
       maintainAspectRatio: false,
       layout: {
         padding: {
-          right: this.state.windowWidth >= 820 ? 100 : undefined
+          left: this.state.windowWidth >= 820 ? 40 : 8,
+          right: this.state.windowWidth >= 820 ? 100 : 16
         }
       },
       scales: {


### PR DESCRIPTION
Per #795, we can fix out-of-bounds labels on the charts with additional padding. (I have checked that the mobile view is not broken by the change.)