### PR TITLE
#646: Center form labels (for tooltip styling)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -299,6 +299,7 @@ form > span > .row > label {
 .form-field-label {
   white-space: nowrap;
   padding-top: 8px;
+  text-align: center;
 }
 
 .metric-chart-label {


### PR DESCRIPTION
Per #646, modal form field labels have been centered to match their hover tool tips.