### PR TITLE
#642: Hide header on mobile portrait view.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -32,6 +32,12 @@ textarea {
   width: 512px;
 }
 
+@media only screen and (max-width: 448px) {
+  .metriq-header {
+      display: none;
+  }
+}
+
 .metriq-navbar {
   background-color: #3cd2f9;
   font-family: 'Arial', sans-serif;

--- a/src/components/MainNavbar.js
+++ b/src/components/MainNavbar.js
@@ -16,7 +16,7 @@ const MainNavbar = (props) =>
         <MainNavRight isLoggedIn={props.isLoggedIn} />
       </Navbar.Collapse>
     </Navbar>
-    <div className='metriq-navbar'>
+    <div className='metriq-navbar metriq-header'>
       <h2>{props.title}</h2>
       <h3>{props.subtitle}</h3>
       <br />


### PR DESCRIPTION
Per #642, to make the design less crowded, we hide the header text in mobile portrait view.