### PR TITLE
Markdown rendering on homepage

### DIFF
--- a/src/components/FeaturedTask.js
+++ b/src/components/FeaturedTask.js
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import axios from 'axios'
 import { Link } from 'react-router-dom'
 import { library } from '@fortawesome/fontawesome-svg-core'
+import { renderLatex } from './RenderLatex'
 import { faHeart, faExternalLinkAlt, faChartLine } from '@fortawesome/free-solid-svg-icons'
 import config from '../config'
 import SotaChart from './SotaChart'
@@ -83,7 +84,7 @@ const FeaturedTask = (props) => {
                 <span> <Link to='/QEDC' onMouseEnter={handleOnMouseEnter} onMouseLeave={handleOnMouseLeave}><span className='link'>(QED-C)</span></Link></span>}
               <span className='float-right'><SubscribeButton item={item} type='task' isLoggedIn={props.isLoggedIn} onMouseEnter={handleOnMouseEnter} onMouseLeave={handleOnMouseLeave} /></span>
             </h5>
-            {description}
+            {description ? renderLatex(description) : ""}
           </div>
         </div>
         <div className='row h-100'>


### PR DESCRIPTION
In this pull request, I have addressed the issue by ensuring that LaTeX is properly rendered in the descriptions of featured tasks item listing on the homepage as it happens on other sections. Specifically, any text elements surrounded by the $ delimiters are now correctly processed and displayed as LaTeX. [Unitary Hack 2024]

![Captura de pantalla 2024-06-01 a la(s) 2 25 45 a m](https://github.com/unitaryfund/metriq-app/assets/764775/399c12bb-ccfd-46cc-8d25-5ca065fda674)
