### PR TITLE
Fix race condition causing Safari browser to hang

### DIFF
--- a/src/components/MainSearchBar.js
+++ b/src/components/MainSearchBar.js
@@ -18,54 +18,27 @@ const MainSearchBar = () => {
       return
     }
 
-    axios.get(config.api.getUriPrefix() + '/task/names')
-      .then(res => {
-        const tNames = res.data.data
+    const fetchNames = async () => {
+      try {
+        const { data: { data: tNames } } = await axios.get(config.api.getUriPrefix() + '/task/names')
+        const { data: { data: mNames } } = await axios.get(config.api.getUriPrefix() + '/method/names')
+        const { data: { data: pNames } } = await axios.get(config.api.getUriPrefix() + '/platform/names')
+        const { data: { data: tgNames } } = await axios.get(config.api.getUriPrefix() + '/tag/names')
+        const { data: { data: sNames } } = await axios.get(config.api.getUriPrefix() + '/submission/names')
+
         setTaskNames(tNames)
-
-        axios.get(config.api.getUriPrefix() + '/method/names')
-          .then(res => {
-            const mNames = res.data.data
-            setMethodNames(mNames)
-
-            axios.get(config.api.getUriPrefix() + '/platform/names')
-              .then(res => {
-                const pNames = res.data.data
-                setPlatformNames(pNames)
-
-                axios.get(config.api.getUriPrefix() + '/tag/names')
-                  .then(res => {
-                    const tgNames = res.data.data
-                    setTagNames(tgNames)
-
-                    axios.get(config.api.getUriPrefix() + '/submission/names')
-                      .then(res => {
-                        const sNames = res.data.data
-                        setSubmissionNames(sNames)
-
-                        setAllNames(tNames.concat(mNames).concat(pNames).concat(tgNames).concat(sNames))
-                      })
-                      .catch(err => {
-                        console.log(err)
-                      })
-                  })
-              })
-              .catch(err => {
-                console.log(err)
-              })
-          })
-          .catch(err => {
-            console.log(err)
-          })
-      })
-      .catch(err => {
+        setMethodNames(mNames)
+        setPlatformNames(pNames)
+        setTagNames(tgNames)
+        setSubmissionNames(sNames)
+        setAllNames([...tNames, ...mNames, ...pNames, ...tgNames, ...sNames])
+      } catch (err) {
         console.log(err)
-      })
-  }, [allNames, setAllNames,
-    taskNames, setTaskNames,
-    methodNames, setMethodNames,
-    platformNames, setPlatformNames,
-    submissionNames, setSubmissionNames])
+      }
+    }
+
+    fetchNames()
+  }, [allNames.length])
 
   const handleOnSelect = (value) => {
     if (!value) {


### PR DESCRIPTION
closes #851

## Reproducing the issue
Please find the video attached where we can see the safari page hung with the metriq-api logs. Can be replicated by running the metriq-app locally with metriq-api and force reloading the page in Safari version 17.2.1

https://github.com/unitaryfund/metriq-app/assets/19835609/584db49f-ee32-41b4-86e9-e0ee7e1021a6

## Analysis

The metriq-app frontend in safari is performing multiple unnecessarily metriq-api server REST APIs in an infinite loop when refreshing the page. Then the page hangs. This is because the useEffect hook is running multiple times because it's watching too many dependencies i.e it's watching all the state variables and their setters. This creates a race condition to update the dependencies of useEffect.

We want the useEffect hook should only be dependent on allNames.length because we only want to fetch data when allNames is empty. 
