### PR TITLE
Work-around for bug in Chrome Array.prototype.sort()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4724,16 +4724,6 @@
         "@types/json-schema": "*"
       }
     },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -15149,9 +15139,9 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -20652,12 +20642,11 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.93.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.93.0.tgz",
-      "integrity": "sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==",
+      "version": "5.94.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
+      "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
       "license": "MIT",
       "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
         "@webassemblyjs/wasm-edit": "^1.12.1",
@@ -20666,7 +20655,7 @@
         "acorn-import-attributes": "^1.9.5",
         "browserslist": "^4.21.10",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.0",
+        "enhanced-resolve": "^5.17.1",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",

--- a/src/components/QuantumVolumeChart.js
+++ b/src/components/QuantumVolumeChart.js
@@ -123,7 +123,7 @@ function dayIndexInEpoch(dateString) {
   // It doesn't need to be exact; it just needs to be unique and maintain order.
   var [year, month, date] = dateString.split("-").map(Number)
 
-  return (year - 1960) * 366 + (month - 1) * 32 + date
+  return (year - 1960) * 372 + (month - 1) * 31 + date
 }
 
 function barplot (

--- a/src/components/QuantumVolumeChart.js
+++ b/src/components/QuantumVolumeChart.js
@@ -138,8 +138,6 @@ function barplot (
   const height = yRange[0] - yRange[1]
   const yMin = d3.min(Y)
   const yDomain = [yMin < 1 ? yMin : 1, d3.max(Y)]
-  console.log(yDomain)
-  console.log(yRange)
   const x = d3.scaleBand()
     .range([xRange[0], xRange[1]])
     .domain(data.map((i) => { if (i.arXiv && areLabelsArxiv) { return `arXiv:${i.arXiv}` } else { return i.platformName ? i.platformName : i.methodName } }))
@@ -467,7 +465,6 @@ function plot (
 
   let chronData = [...data]
   quickSort(chronData, 0, chronData.length - 1)
-  console.log(chronData)
   const maxIDs = [chronData[0].id]
   let currentMaxValue = chronData[0].metricValue
   for (let lcv = 1; lcv < chronData.length; ++lcv) {


### PR DESCRIPTION
In Chrome, the state-of-the-art line was rendered incorrectly on charts like Quantum Volume.

As can be seen in the PR, this is _purely_ a bug in _Chrome._ By resorting to _manual_ date parsing and sorting, we work around it.