### PR TITLE
Automate Copyright Updates

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -7,6 +7,11 @@ on:
   push:
     branches: [ main ]
 
+  schedule:
+    # This cron expression schedules the job to run at 12:01 AM on January 1st
+    # which will keep the copyright notice up-to-date.
+    - cron: '1 0 1 1 *'
+
 jobs:
   deployment:
 

--- a/src/App.js
+++ b/src/App.js
@@ -2,24 +2,30 @@ import './App.css'
 import MainRouter from './MainRouter'
 import SimpleReactFooter from './components/simple-react-footer/SimpleReactFooter'
 
-const App = () =>
-  <div className='App'>
-    <MainRouter />
-    <SimpleReactFooter
-      title='metriq'
-      description='Quantum computing benchmarks by community contributors'
-      copyright='2021-2024 Unitary Fund'
-      discord='unitary.fund'
-      github='unitaryfund'
-      twitch='unitaryfund'
-      twitter='unitaryfund'
-      youtube='UCDbDLAzGRTHnhkoMMOX7D1A'
-      linkedin='unitary-fund'
-      backgroundColor='#04165D'
-      fontColor='#FFFFFF'
-      iconColor='#FFFFFF'
-      copyrightColor='#FFFFFF'
-    />
-  </div>
+const App = () => {
+    const currentYear = new Date().getFullYear();
+    const copyrightYear = `2021-${currentYear} Unitary Fund`;
+
+    return (
+        <div className='App'>
+            <MainRouter/>
+            <SimpleReactFooter
+                title='metriq'
+                description='Quantum computing benchmarks by community contributors'
+                copyright={copyrightYear}
+                discord='unitary.fund'
+                github='unitaryfund'
+                twitch='unitaryfund'
+                twitter='unitaryfund'
+                youtube='UCDbDLAzGRTHnhkoMMOX7D1A'
+                linkedin='unitary-fund'
+                backgroundColor='#04165D'
+                fontColor='#FFFFFF'
+                iconColor='#FFFFFF'
+                copyrightColor='#FFFFFF'
+            />
+        </div>
+    );
+}
 
 export default App


### PR DESCRIPTION
The PR will automatically calculate the to-year in the copyright notice, so that it does not need to be updated in the future. It also adds a scheduled deployment to Github Actions on 1 January so the copyright notice is immediately updated at the  start of the year.