### PR TITLE
Only link to up-to-date tasks on SOTA page

### DIFF
--- a/src/components/SotaItem.js
+++ b/src/components/SotaItem.js
@@ -12,18 +12,6 @@ const SotaItem = (props) =>
         <p>{props.description}</p>
       </div>
     </div>
-    <div className='row'>
-      <label htmlFor={props.name + '-value'} className='col-md-1 text-start'>Value:</label>
-      <div className='col-md-6 text-start'><Link to={'/Submission/' + props.submissionId}>{props.value}</Link></div>
-    </div>
-    <div className='row'>
-      <label htmlFor={props.name + '-value'} className='col-md-1 text-start'>{props.isPlatform ? 'Platform:' : 'Method:'}</label>
-      <div className='col-md-6 text-start'>{props.method}</div>
-    </div>
-    <div className='row'>
-      <label htmlFor={props.name + '-value'} className='col-md-1 text-start'>Architecture:</label>
-      <div className='col-md-6 text-start'>{props.architecture}</div>
-    </div>
     <br />
   </span>
 

--- a/src/views/Sota.js
+++ b/src/views/Sota.js
@@ -11,7 +11,7 @@ const Sota = (props) => {
       </div>
       <div className='row'>
         <div className='col text-start'>
-          <p>These are benchmarks that the Metriq team thinks give a handle on understanding the state-of-the-art in quantum computing. Click into each task comparison to see the latest data.</p>
+          <p>These are benchmarks that the Metriq team thinks give a handle on understanding the state-of-the-art in quantum computing. Click into each task comparison title link to see the latest data.</p>
         </div>
       </div>
       <br />

--- a/src/views/Sota.js
+++ b/src/views/Sota.js
@@ -9,6 +9,11 @@ const Sota = (props) => {
           <h4 align='left'>State of the Art Quantum Benchmarks</h4>
         </div>
       </div>
+      <div className='row'>
+        <div className='col text-start'>
+          <p>These are benchmarks that the Metriq team thinks give a handle on understanding the state-of-the-art in quantum computing. Click into each task comparison to see the latest data.</p>
+        </div>
+      </div>
       <br />
       <div className='row'>
         <div className='col'>
@@ -19,7 +24,7 @@ const Sota = (props) => {
       <SotaItem
         title='Quantum Volume'
         description='The Log-2 Quantum Volume is otherwise known as "algorithmic qubits" (in the absence of error correction) and constitutes the effective number of viable logical qubits (for QV-like tasks).'
-        value='2^20'
+        value='2^21'
         submissionId={642}
         taskId={34}
         method={<Link to={'/Platform/' + 80}>Quantinuum System Model H1-1</Link>}


### PR DESCRIPTION
Per a committee member's suggestion, I agree that only linking to the task charts on the SOTA page is an improvement over the standing design (which has fallen out-of-date).