### PR TITLE
Potential fix for code scanning alert no. 6: Server-side request forgery

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -43,6 +43,11 @@ app.get('*', (req, res, next) => {
 
     if (req.url.startsWith('/Submission/')) {
       const id = truncateBefore(req.url, '/Submission/')
+      const idPattern = /^[a-zA-Z0-9_-]+$/; // Allow only alphanumeric, underscores, and hyphens
+      if (!idPattern.test(id)) {
+        console.error('Invalid ID format:', id);
+        return res.status(400).send('Invalid ID format');
+      }
       const route = config.api.getUriPrefix() + '/submission/' + id
       await (axios.get(route)
         .then(subRes => {
@@ -70,6 +75,11 @@ app.get('*', (req, res, next) => {
         }))
     } else if (req.url.startsWith('/Platform/')) {
       const id = truncateBefore(req.url, '/Platform/')
+      const idPattern = /^[a-zA-Z0-9_-]+$/; // Allow only alphanumeric, underscores, and hyphens
+      if (!idPattern.test(id)) {
+        console.error('Invalid ID format:', id);
+        return res.status(400).send('Invalid ID format');
+      }
       const route = config.api.getUriPrefix() + '/platform/' + id
       await (axios.get(route)
         .then(subRes => {


### PR DESCRIPTION
Potential fix for [https://github.com/unitaryfoundation/metriq-app/security/code-scanning/6](https://github.com/unitaryfoundation/metriq-app/security/code-scanning/6)

To fix the SSRF vulnerability, we need to validate and sanitize the user input (`id`) before using it to construct the `route`. Specifically:
1. Ensure that the `id` conforms to an expected format (e.g., alphanumeric, UUID, or numeric).
2. Use a fixed, trusted base URL for the API endpoint (`config.api.getUriPrefix()`), and ensure that the `id` cannot alter the domain or path structure.
3. Reject or handle invalid inputs gracefully to prevent malicious requests.

The best approach is to validate the `id` using a regular expression or a similar mechanism to ensure it matches the expected format. If the `id` is invalid, return an appropriate error response.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
