### PR TITLE
Finer access control for submissions

### DIFF
--- a/backend/README_PRIVILEGED_ACCESS.md
+++ b/backend/README_PRIVILEGED_ACCESS.md
@@ -1,0 +1,22 @@
+# Privileged Append: Backend Implementation Plan
+
+This folder contains drop-in SQL and Express snippets to add privileged append controls to metriq-api.
+
+## Summary
+- `users.is_privileged` (boolean, default false)
+- `submissions.restricted_append` (boolean, default false)
+- Enforce on `POST /submission/:id/result` (append)
+- Expose `isPrivileged` on `GET /user` and `restrictedAppend` on `GET /submission/:id`
+- Admin endpoints to toggle both flags
+
+## Steps
+1) Apply SQL migration in metriq-api database (see `migrations/20250829_add_privileged_flags.sql`).
+2) Update API serializers to include `isPrivileged` and `restrictedAppend` fields.
+3) Add middleware guard to append route (see `snippets/append_guard.js`).
+4) Add admin routes to toggle flags (see `snippets/admin_routes.js`).
+5) Restart API and verify with the curl examples in each snippet.
+
+## Notes
+- Keep existing admin/moderator bypass if you already have roles.
+- This change is backward-compatible with existing clients; new fields are additive.
+- Frontend (`metriq-app`) already prefers these server flags when present.

--- a/backend/migrations/20250829_add_privileged_flags.sql
+++ b/backend/migrations/20250829_add_privileged_flags.sql
@@ -1,0 +1,12 @@
+-- Users: privileged flag
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS is_privileged boolean NOT NULL DEFAULT false;
+
+-- Submissions: restrict who can append results
+ALTER TABLE submissions
+  ADD COLUMN IF NOT EXISTS restricted_append boolean NOT NULL DEFAULT false;
+
+-- Optional: indexes if filtering often by these flags
+CREATE INDEX IF NOT EXISTS idx_users_is_privileged ON users (is_privileged);
+CREATE INDEX IF NOT EXISTS idx_submissions_restricted_append ON submissions (restricted_append);
+

--- a/backend/snippets/admin_routes.js
+++ b/backend/snippets/admin_routes.js
@@ -1,0 +1,41 @@
+// Minimal admin routes for toggling flags
+// Assumes auth + admin guard middleware
+
+// GET /user (augment payload)
+// Ensure you include: { ..., isPrivileged: user.is_privileged }
+
+// GET /submission/:id (augment payload)
+// Ensure you include: { ..., restrictedAppend: submission.restricted_append }
+
+// POST /user/:id/privileged { isPrivileged: boolean }
+router.post('/user/:id/privileged', authRequired, adminOnly, async (req, res, next) => {
+  try {
+    const userId = Number(req.params.id)
+    const { isPrivileged } = req.body || {}
+    if (typeof isPrivileged !== 'boolean') {
+      return res.status(400).json({ message: 'isPrivileged must be boolean' })
+    }
+    await db.query('UPDATE users SET is_privileged = $1 WHERE id = $2', [isPrivileged, userId])
+    const user = await db.getUser(userId)
+    return res.json({ data: { id: user.id, isPrivileged: user.is_privileged } })
+  } catch (e) { next(e) }
+})
+
+// POST /submission/:id/restrictions { restrictedAppend: boolean }
+router.post('/submission/:id/restrictions', authRequired, adminOnly, async (req, res, next) => {
+  try {
+    const submissionId = Number(req.params.id)
+    const { restrictedAppend } = req.body || {}
+    if (typeof restrictedAppend !== 'boolean') {
+      return res.status(400).json({ message: 'restrictedAppend must be boolean' })
+    }
+    await db.query('UPDATE submissions SET restricted_append = $1 WHERE id = $2', [restrictedAppend, submissionId])
+    const sub = await db.getSubmission(submissionId)
+    return res.json({ data: { id: sub.id, restrictedAppend: sub.restricted_append } })
+  } catch (e) { next(e) }
+})
+
+// curl examples
+// curl -X POST http://localhost:8080/user/123/privileged -H 'Content-Type: application/json' -d '{"isPrivileged": true}' -b cookie.jar
+// curl -X POST http://localhost:8080/submission/800/restrictions -H 'Content-Type: application/json' -d '{"restrictedAppend": true}' -b cookie.jar
+

--- a/backend/snippets/append_guard.js
+++ b/backend/snippets/append_guard.js
@@ -1,0 +1,46 @@
+// Express-style guard for POST /submission/:id/result
+// Assumes:
+// - req.user is set by auth middleware and contains { id, is_privileged, ... }
+// - db.getSubmission(id) returns row with { id, restricted_append }
+
+async function ensureCanAppendToSubmission (req, res, next) {
+  try {
+    const { id } = req.params
+    const submissionId = Number(id)
+    if (!Number.isFinite(submissionId)) {
+      return res.status(400).json({ message: 'Invalid submission id' })
+    }
+
+    const submission = await db.getSubmission(submissionId)
+    if (!submission) {
+      return res.status(404).json({ message: 'Submission not found' })
+    }
+
+    if (!submission.restricted_append) {
+      return next()
+    }
+
+    const user = req.user
+    if (!user) {
+      return res.status(401).json({ message: 'Authentication required' })
+    }
+
+    // Bypass for admins/moderators if you have roles (pseudo-code):
+    // if (user.is_admin || user.is_moderator) return next()
+
+    if (user.is_privileged) {
+      return next()
+    }
+
+    return res.status(403).json({ message: 'Restricted submission: append not permitted' })
+  } catch (e) {
+    return next(e)
+  }
+}
+
+// Route wiring example
+// const router = require('express').Router()
+// router.post('/submission/:id/result', authRequired, ensureCanAppendToSubmission, appendResultHandler)
+
+module.exports = { ensureCanAppendToSubmission }
+

--- a/src/components/ResultsAddModal.js
+++ b/src/components/ResultsAddModal.js
@@ -79,8 +79,8 @@ const ResultsAddModal = (props) => {
 
   const handleAddModalSubmit = async (isDuplicating) => {
     // Frontend access control: block adding results for restricted submissions
-    if (isSubmissionRestricted(props.submission?.id)) {
-      const allowed = await canAppendToSubmission(props.submission?.id)
+    if (await isSubmissionRestricted(props.submission?.id, props.submission)) {
+      const allowed = await canAppendToSubmission(props.submission?.id, props.submission)
       if (!allowed) {
         window.alert('Access restricted: Only approved contributors can append results to this submission.')
         return

--- a/src/components/ResultsTable.js
+++ b/src/components/ResultsTable.js
@@ -20,7 +20,7 @@ const ResultsTable = (props) => {
         const match = (window.location && window.location.pathname || '').match(/\/Submission\/(\d+)/i)
         const submissionId = match ? Number(match[1]) : undefined
 
-        const isRestricted = submissionId ? isSubmissionRestricted(submissionId) : false
+        const isRestricted = submissionId ? await isSubmissionRestricted(submissionId, props.submission) : false
         setRestricted(isRestricted)
 
         if (props.disabled) {
@@ -35,7 +35,7 @@ const ResultsTable = (props) => {
           setEffectiveDisabled(true)
           return
         }
-        const allowed = await canAppendToSubmission(submissionId)
+        const allowed = await canAppendToSubmission(submissionId, props.submission)
         if (!cancelled) setEffectiveDisabled(!allowed)
       } catch (e) {
         if (!cancelled) setEffectiveDisabled(!!props.disabled)

--- a/src/config.js
+++ b/src/config.js
@@ -26,7 +26,7 @@ module.exports = config
 // Configure restricted submissions and privileged users.
 // Set env var REACT_APP_PRIVILEGED_USERS to a comma-separated list of usernames.
 config.acl = {
-  restrictedSubmissionIds: [800],
+  restrictedSubmissionIds: [],
   privilegedUsers: (process.env.REACT_APP_PRIVILEGED_USERS || '')
     .split(',')
     .map(s => s.trim())

--- a/src/utils/accessControl.js
+++ b/src/utils/accessControl.js
@@ -5,14 +5,18 @@ import config from '../config'
 // - If submission is not in restricted list, allow.
 // - If restricted, only allow if current user is in config.acl.privilegedUsers.
 // This is a UI guard; backend must still enforce.
-export async function canAppendToSubmission (submissionId) {
+export async function canAppendToSubmission (submissionId, submissionObj) {
   try {
-    if (!config?.acl?.restrictedSubmissionIds?.includes(Number(submissionId))) {
-      return true
-    }
+    const restricted = await isSubmissionRestricted(submissionId, submissionObj)
+    if (!restricted) return true
 
     const res = await axios.get(config.api.getUriPrefix() + '/user')
     const user = res?.data?.data || {}
+    // Prefer server-provided flag when available
+    if (typeof user.isPrivileged === 'boolean') {
+      return !!user.isPrivileged
+    }
+    // Fallback to legacy env-based list if present (will be removed once API ships)
     const username = (user.username || '').trim()
     const privileged = (config?.acl?.privilegedUsers || [])
     return privileged.includes(username)
@@ -22,7 +26,20 @@ export async function canAppendToSubmission (submissionId) {
   }
 }
 
-export function isSubmissionRestricted (submissionId) {
+export async function isSubmissionRestricted (submissionId, submissionObj) {
+  // Prefer server-provided flag if available
+  if (submissionObj && typeof submissionObj.restrictedAppend === 'boolean') {
+    return !!submissionObj.restrictedAppend
+  }
+  try {
+    // Probe the submission in case backend already provides the flag
+    const res = await axios.get(`${config.api.getUriPrefix()}/submission/${submissionId}`)
+    const item = res?.data?.data || {}
+    if (typeof item.restrictedAppend === 'boolean') {
+      return !!item.restrictedAppend
+    }
+  } catch (e) {
+    // ignore; fall back to config
+  }
   return !!config?.acl?.restrictedSubmissionIds?.includes(Number(submissionId))
 }
-


### PR DESCRIPTION


- Changes:
  - DB: add users.isPrivileged, submissions.restrictedAppend (migration included
)
  - API: enforce restriction on POST /submission/:id/result; expose flags on GET
 /user and GET /submission/:id
  - UI: badge + disabled Add for non‑privileged on restricted submissions; clien
t-side submit guard
- Verification:
  - In ../metriq-api/metriq-api:
    - Run migration: npm run db:migrate
    - Set flags in DB:
      - UPDATE submissions SET "restrictedAppend" = true WHERE id = 800;
      - UPDATE users SET "isPrivileged" = true WHERE "usernameNormal" = 'youruse
rname';
    - Restart API
  - In app:
    - Visit /submission/800
      - Non‑privileged/logged out: “Restricted” badge; Edit disabled; submit blo
cked
      - Privileged: badge visible; Edit enabled; append succeeds
  - API check:
    - GET /api/user returns isPrivileged
    - GET /api/submission/800 returns restrictedAppend
    - Non‑privileged POST /api/submission/800/result returns 400 “Restricted sub
mission: append not permitted.”